### PR TITLE
Add .shrink utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 [![Build Status](https://travis-ci.org/zazuko/rdf-vocabularies.svg?branch=master)](https://travis-ci.org/zazuko/rdf-vocabularies) 
 [![Coverage Status](https://coveralls.io/repos/github/zazuko/rdf-vocabularies/badge.svg?branch=master)](https://coveralls.io/github/zazuko/rdf-vocabularies?branch=master)
 
-This package contains a distribution of the most commonly used RDF ontologies (schema/vocab, whatever you call it) including their default prefixes.
+This package contains a distribution of the most commonly used RDF ontologies (schema/vocab, whatever you call it)
+including their default prefixes.
 
-It is extending [RDFa Core Initial Context](http://www.w3.org/2011/rdfa-context/rdfa-1.1) and contains what we consider commonly used prefixes. Some popular prefixes do not resolve to dereferencable RDF and are thus skipped.
+It is extending [RDFa Core Initial Context](http://www.w3.org/2011/rdfa-context/rdfa-1.1) and contains what we consider
+commonly used prefixes. Some popular prefixes do not resolve to dereferencable RDF and are thus skipped.
 
-The package is built for use in Node.js projects. We ship N-Quads files of the vocabularies so it could be useful for other programming languages as well as you do not have to take care of downloading the ontologies yourself.
+The package is built for use in Node.js projects. We ship N-Quads files of the vocabularies so it could be useful for
+other programming languages as well as you do not have to take care of downloading the ontologies yourself.
 
 ## Installation
 
@@ -175,4 +178,8 @@ Updating the vendored ontologies is achieved using `npm run fetch` in this packa
 
 ## Adding new prefixes
 
-New prefixes can be added by opening a pull request on Github. For new requests, first check if the creator/owner of the namespace defined a prefix. If not check [prefix.cc](http://prefix.cc/). In case prefix.cc is ambiguous a discussion should be raised before the pull-requests gets integrated. Last thing to check are the predefined namespaces in the [DBpedia SPARQL endpoint](http://dbpedia.org/sparql?nsdecl) or other popular RDF resources like [LOV](https://lov.linkeddata.es/dataset/lov/vocabs). If you find one please refer to it in the pull request.
+New prefixes can be added by opening a pull request on Github. For new requests, first check if the creator/owner
+of the namespace defined a prefix. If not check [prefix.cc](http://prefix.cc/). In case prefix.cc is ambiguous a
+discussion should be raised before the pull-requests gets integrated. Last thing to check are the predefined namespaces
+in the [DBpedia SPARQL endpoint](http://dbpedia.org/sparql?nsdecl) or other popular RDF resources like
+[LOV](https://lov.linkeddata.es/dataset/lov/vocabs). If you find one please refer to it in the pull request.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/zazuko/rdf-vocabularies/badge.svg?branch=master)](https://coveralls.io/github/zazuko/rdf-vocabularies?branch=master)
 
 This package contains a distribution of the most commonly used RDF ontologies (schema/vocab, whatever you call it)
-including their default prefixes.
+including their default prefixes, together with a set of utility functions to work with prefixes.
 
 It is extending [RDFa Core Initial Context](http://www.w3.org/2011/rdfa-context/rdfa-1.1) and contains what we consider
 commonly used prefixes. Some popular prefixes do not resolve to dereferencable RDF and are thus skipped.
@@ -116,6 +116,10 @@ const stream = await rdfVocabularies({ stream: true, only: ['rdfs', 'owl', 'skos
 
 ### Expanding a Prefix
 
+`expand`ing means: `'xsd:dateTime' → 'http://www.w3.org/2001/XMLSchema#dateTime'`.
+It is the opposite of [`shrink`](#shrinking-an-iri)ing:  
+`expand(shrink('http://www.w3.org/2001/XMLSchema#dateTime')) === 'http://www.w3.org/2001/XMLSchema#dateTime'`
+
 There are two ways of expanding a prefix:
 
 * `rdfVocabularies.expand(prefixedTerm: String): String` synchronous
@@ -126,19 +130,42 @@ There are two ways of expanding a prefix:
 * `rdfVocabularies.expand(prefixedTerm: String, types: Array<String|NamedNode>): Promise<String>` **asynchronous**
 
     Expand with type checks. `types` is an array of strings or NamedNodes. See this example:
+
     ```js
-    const rdfVocabularies = require('@zazuko/rdf-vocabularies')
-    const Class = rdfVocabularies.expand('rdfs:Class')
-    const Property = rdfVocabularies.expand('rdf:Property')
+    const { expand } = require('@zazuko/rdf-vocabularies')
+    const Class = expand('rdfs:Class')
+    const Property = expand('rdf:Property')
 
     // Will return <schema:person> expanded to `http://schema.org/Person`
     // iff the dataset contains either:
     //   <schema:Person> <rdf:type> <rdfs:Class>
     // or
     //   <schema:Person> <rdf:type> <rdf:Property>
-    await rdfVocabularies.expand('schema:Person', [Class, Property])
+    await expand('schema:Person', [Class, Property])
     ```
 
+### Shrinking an IRI
+
+`shrink`ing means: `'http://www.w3.org/2001/XMLSchema#dateTime' → 'xsd:dateTime'`.
+It is the opposite of [`expand`](#expanding-a-prefix)ing:  
+`shrink(expand('xsd:dateTime')) === 'xsd:dateTime'`
+
+* `rdfVocabularies.shrink(iri: String): String`
+
+    **Note**: returns empty string when there is no corresponding prefix. Always check the output
+    when using `shrink` with user-provided strings.
+
+    ```js
+    const assert = require('assert')
+    const { shrink } = require('@zazuko/rdf-vocabularies')
+
+    assert(shrink('http://www.w3.org/2001/XMLSchema#dateTime') === 'xsd:dateTime')
+    assert(shrink('http://example.com#nothing') === '')
+
+    const iri = 'http://example.com#nothing'
+    const stringToDisplay = shrink(iri) || iri
+    console.log(stringToDisplay) // 'http://example.com#nothing'
+    ```
 
 ### Accessing Prefixes: `rdfVocabularies.prefixes`
 

--- a/examples.js
+++ b/examples.js
@@ -1,4 +1,5 @@
 const rdfVocabularies = require('.')
+const { prefixes, expand, shrink } = rdfVocabularies
 
 Promise.resolve().then(run)
 
@@ -12,17 +13,19 @@ async function run () {
 
   console.warn('\nGet base URI for', customSelection)
   customSelection.forEach((prefix) => {
-    const uri = rdfVocabularies.prefixes[prefix]
+    const uri = prefixes[prefix]
     console.log(`${prefix} => ${uri}`)
   })
 
   console.warn('\nGet a stream', await rdfVocabularies({ only: customSelection, stream: true }))
 
-  const Class = rdfVocabularies.expand('rdfs:Class')
-  const Property = rdfVocabularies.expand('rdf:Property')
+  const Class = expand('rdfs:Class')
+  const Property = expand('rdf:Property')
   console.log(`\nexpanded rdfs:Class => ${Class}`)
-  const person = await rdfVocabularies.expand('schema:Person', [Class, Property])
+  const person = await expand('schema:Person', [Class, Property])
   console.log(`expanded schema:Person => ${person} while checking it exists as either a rdfs:Class or rdf:Property`)
+
+  console.log(`\nshrink ${expand('xsd:Boolean')} to ${shrink(expand('xsd:Boolean'))}`)
 }
 
 async function printQuadsCount (prefixSelection) {

--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@ const { join, resolve } = require('path')
 const ParserN3 = require('@rdfjs/parser-n3')
 const rdf = require('rdf-ext')
 
-const allPrefixes = require('./prefixes')
+const prefixes = require('./prefixes')
 // memoizing the prefixes already used in 'expand'
 const loadedPrefixes = {}
 
 module.exports = load
-module.exports.prefixes = allPrefixes
+module.exports.prefixes = prefixes
 module.exports.expand = expand
 
 async function load ({ only, factory = rdf, stream = false } = {}) {
@@ -18,7 +18,7 @@ async function load ({ only, factory = rdf, stream = false } = {}) {
   if (customSelection) {
     selectedPrefixes = []
     only.forEach(prefix => {
-      if (prefix in allPrefixes) {
+      if (prefix in prefixes) {
         selectedPrefixes.push(prefix)
       }
       else {
@@ -27,7 +27,7 @@ async function load ({ only, factory = rdf, stream = false } = {}) {
     })
   }
   if (!selectedPrefixes) {
-    selectedPrefixes = Object.keys(allPrefixes)
+    selectedPrefixes = Object.keys(prefixes)
   }
 
   const promises = selectedPrefixes.map((prefix) => loadFile(prefix, { customSelection: !!only, factory }))
@@ -69,7 +69,7 @@ function expand (prefixed, types = []) {
     return ''
   }
 
-  const baseIRI = allPrefixes[prefix]
+  const baseIRI = prefixes[prefix]
   if (!baseIRI) {
     throw new Error(`Unavailable prefix '${prefix}:'`)
   }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const loadedPrefixes = {}
 module.exports = load
 module.exports.prefixes = prefixes
 module.exports.expand = expand
+module.exports.shrink = shrink
 
 async function load ({ only, factory = rdf, stream = false } = {}) {
   const customSelection = !!only && Array.isArray(only)
@@ -80,6 +81,14 @@ function expand (prefixed, types = []) {
   }
 
   return expandWithCheck({ prefix, iri, baseIRI, types })
+}
+
+function shrink (iri) {
+  const found = Array.from(Object.entries(prefixes)).find(([, baseIRI]) => iri.startsWith(baseIRI))
+  if (found) {
+    return iri.replace(new RegExp(`^${found[1]}`), `${found[0]}:`)
+  }
+  return ''
 }
 
 function buildPath (prefix) {


### PR DESCRIPTION
> `shrink`ing means: `'http://www.w3.org/2001/XMLSchema#dateTime' → 'xsd:dateTime'`.
> It is the opposite of [`expand`](#expanding-a-prefix)ing:  
> `shrink(expand('xsd:dateTime')) === 'xsd:dateTime'`
> 
>  * `rdfVocabularies.shrink(iri: String): String`
> 
>      **Note**: returns empty string when there is no corresponding prefix. Always check the output
>     when using `shrink` with user-provided strings.
> 
>      ```js
>     const assert = require('assert')
>     const { shrink } = require('@zazuko/rdf-vocabularies')
>
>      assert(shrink('http://www.w3.org/2001/XMLSchema#dateTime') === 'xsd:dateTime')
>     assert(shrink('http://example.com#nothing') === '')
>
>      const iri = 'http://example.com#nothing'
>     const stringToDisplay = shrink(iri) || iri
>     console.log(stringToDisplay) // 'http://example.com#nothing'
>     ```