### PR TITLE
fix: add typings so that custom prefixes can be added

### DIFF
--- a/src/lib/prefixes.ts
+++ b/src/lib/prefixes.ts
@@ -1,4 +1,4 @@
-export default {
+const prefixes = {
   as: 'http://www.w3.org/ns/activitystreams#',
   cc: 'http://creativecommons.org/ns#',
   cnt: 'http://www.w3.org/2011/content#',
@@ -67,3 +67,12 @@ export default {
   xml: 'http://www.w3.org/XML/1998/namespace',
   xsd: 'http://www.w3.org/2001/XMLSchema#'
 }
+
+type KnownPrefixes = {
+  readonly [key in keyof typeof prefixes]: string
+}
+interface CustomPrefixes {
+  [key: string]: string;
+}
+
+export default prefixes as KnownPrefixes & CustomPrefixes


### PR DESCRIPTION
Currently it's not possible to add own prefixes without TypeScript complaining, because the implicit interface of the `prefixes` export only allows the declared prefix names.

With this small change it will be possible and at the same time the built-ins are guarded against modification.

<img width="656" alt="image" src="https://user-images.githubusercontent.com/588128/62763794-ae104380-ba8c-11e9-8ff1-785a8a028ecf.png">

This of course will not prevent any namespace from being changed but at least will warn during build/development.

The downside is that error will not be shown when trying to access a prefix which does not exist on that object...