### PR TITLE
fix(dbpedia): source label file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# vNext
+
+Updated prefixes:
+
+| Prefix | #Quads |
+| ---- | ---- |
+| `dbo` | 39069 |
+
 # `v2019.10.22`
 
 Add `sh:` prefix and vocabulary.

--- a/overrides.js
+++ b/overrides.js
@@ -1,5 +1,14 @@
 module.exports = {
   as: { file: 'https://www.w3.org/ns/activitystreams-owl.ttl', mediaType: 'text/turtle' },
+  dbo: {
+    files: [{
+      mediaType: 'text/n3',
+      file: 'http://downloads.dbpedia.org/2016-10/dbpedia_2016-10.nt'
+    }, {
+      mediaType: 'text/turtle',
+      file: 'http://dbpedia.org/ontology/'
+    }]
+  },
   cc: { file: 'https://creativecommons.org/schema.rdf' },
   ctag: { skip: true },
   dtype: { mediaType: 'application/rdf+xml' },


### PR DESCRIPTION
The ontology file we were sourcing for dbpedia only contained `rdfs:isDefinedBy` for each term: <https://prefix.zazuko.com/dbo:Actor>.

I added another source file that also contains labels.