### PR TITLE
fix: missing package.json export

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
       "require": "./vocabularies.js",
       "import": "./vocabularies.mjs"
     },
+    "./prefixes": {
+      "require": "./prefixes.js",
+      "import": "./prefixes.mjs"
+    },
     "./datasets": {
       "require": "./datasets/index.js",
       "import": "./datasets/index.mjs"


### PR DESCRIPTION
I missed one `package.json` entry and it's impossible to import `@zazuko/rdf-vocabularies/packages` in node 13/14