### PR TITLE
refactor: split expand and expandWithCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# `vNext`
+
+## Changes
+
+- The module `@zazuko/rdf-vocabularies/expand` now only does simple expansion (no second parameter).
+
 # `v2020.11.2`
 
 ## Changes

--- a/README.md
+++ b/README.md
@@ -145,11 +145,10 @@ The preferred usage in browser projects is to avoid importing from `@zazuko/rdf-
 Instead, import from the partial modules:
 
 * `import { expand } from '@zazuko/rdf-vocabularies/expand'`
-* `import { expandWithCheck } from '@zazuko/rdf-vocabularies/expandWithCheck'`
 * `import { prefixes } from '@zazuko/rdf-vocabularies/prefixes'`
 * `import { shrink } from '@zazuko/rdf-vocabularies/shrink'`
 
-Except for `expandWithCheck`, which imports `rdf-ext`, all those other modules have no dependencies.
+The module `@zazuko/rdf-vocabularies/expandWithCheck` requires `rdf-ext` and parses datasets. See the instructions below for examples how to configure the application.
 
 The package's main module can also be used in browser albeit it needs a bundler such as webpack and additional steps to configure it:
 

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -1,12 +1,9 @@
-import { NamedNode } from 'rdf-js'
 import prefixes from './prefixes'
 
-export function expand (prefixed: string): string;
-export function expand (prefixed: string, types: (string | NamedNode)[]): Promise<string>;
-export function expand (prefixed: string, types: (string | NamedNode)[] = []): string | Promise<string> {
+export function getParts (prefixed: string): { term: string; baseIRI: string; prefix: string } | null {
   const [prefix, term] = prefixed.split(':')
   if (!prefix || !term) {
-    return ''
+    return null
   }
 
   const baseIRI = prefixes[prefix]
@@ -14,11 +11,14 @@ export function expand (prefixed: string, types: (string | NamedNode)[] = []): s
     throw new Error(`Unavailable prefix '${prefix}:'`)
   }
 
-  const iri = `${baseIRI}${term}`
-  if (!types.length) {
-    return iri
+  return { prefix, term, baseIRI }
+}
+
+export function expand (prefixed: string): string {
+  const parts = getParts(prefixed)
+  if (!parts) {
+    return ''
   }
 
-  return import('./expandWithCheck')
-    .then(({ expandWithCheck }) => expandWithCheck({ prefix, iri, baseIRI, types }))
+  return `${parts.baseIRI}${parts.term}`
 }

--- a/src/expandWithCheck.ts
+++ b/src/expandWithCheck.ts
@@ -1,19 +1,40 @@
 import { NamedNode } from 'rdf-js'
 import rdf from 'rdf-ext'
 import { vocabularies, Datasets } from './vocabularies'
-import { expand } from './expand'
+import { expand, getParts } from './expand'
 
 // memoizing the prefixes already used in 'expand'
 export const loadedPrefixes: Datasets = {}
+
+type Types = (string | NamedNode)[]
 
 interface ExpandWithCheckOptions {
   prefix: string;
   iri: string;
   baseIRI: string;
-  types: (string | NamedNode)[];
+  types: Types;
 }
 
-export async function expandWithCheck ({ prefix, iri, baseIRI, types }: ExpandWithCheckOptions): Promise<string> {
+export async function expandWithCheck (prefixed: string, types: Types): Promise<string>
+export async function expandWithCheck ({ prefix, iri, baseIRI, types }: ExpandWithCheckOptions): Promise<string>
+export async function expandWithCheck (arg: ExpandWithCheckOptions | string, _types: Types = []): Promise<string> {
+  let prefix: string
+  let term: string
+  let baseIRI: string
+  let types: (string | NamedNode)[] = _types
+
+  if (typeof arg === 'string') {
+    const parts = getParts(arg)
+    if (!parts) {
+      return ''
+    }
+
+    ({ prefix, term, baseIRI } = parts)
+  }
+  else {
+    ({ prefix, iri: term, baseIRI, types } = arg)
+  }
+
   if (!(prefix in loadedPrefixes)) {
     // if not previously loaded, load and memoize for later use
     const datasets = await vocabularies({ only: [prefix], factory: rdf })
@@ -21,6 +42,7 @@ export async function expandWithCheck ({ prefix, iri, baseIRI, types }: ExpandWi
   }
   const dataset = loadedPrefixes[prefix]
 
+  const iri = `${baseIRI}${term}`
   const typesNamedNodes = types.map(type => typeof type === 'string' ? rdf.namedNode(type) : type)
   const typeTerm = rdf.namedNode(expand('rdf:type'))
   const graph = rdf.namedNode(baseIRI)

--- a/src/expandWithCheck.ts
+++ b/src/expandWithCheck.ts
@@ -8,32 +8,13 @@ export const loadedPrefixes: Datasets = {}
 
 type Types = (string | NamedNode)[]
 
-interface ExpandWithCheckOptions {
-  prefix: string;
-  iri: string;
-  baseIRI: string;
-  types: Types;
-}
-
-export async function expandWithCheck (prefixed: string, types: Types): Promise<string>
-export async function expandWithCheck ({ prefix, iri, baseIRI, types }: ExpandWithCheckOptions): Promise<string>
-export async function expandWithCheck (arg: ExpandWithCheckOptions | string, _types: Types = []): Promise<string> {
-  let prefix: string
-  let term: string
-  let baseIRI: string
-  let types: (string | NamedNode)[] = _types
-
-  if (typeof arg === 'string') {
-    const parts = getParts(arg)
-    if (!parts) {
-      return ''
-    }
-
-    ({ prefix, term, baseIRI } = parts)
+export async function expandWithCheck (prefixed: string, types: Types): Promise<string> {
+  const parts = getParts(prefixed)
+  if (!parts) {
+    return ''
   }
-  else {
-    ({ prefix, iri: term, baseIRI, types } = arg)
-  }
+
+  const { prefix, term, baseIRI } = parts
 
   if (!(prefix in loadedPrefixes)) {
     // if not previously loaded, load and memoize for later use

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,7 +5,7 @@ import { join, resolve as resolvePath } from 'path'
 import rdf from 'rdf-ext'
 import { vocabularies } from './vocabularies'
 import { shrink } from './shrink'
-import { expand } from './expand'
+import { expand } from './'
 import prefixes from './prefixes'
 
 const list = (directoryPath: string): Promise<string[]> =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,18 @@
+import { expandWithCheck } from './expandWithCheck'
+import { expand as _expand } from './expand'
+import { NamedNode } from 'rdf-js'
+
 export { default as prefixes } from './prefixes'
 export { vocabularies, loadFile } from './vocabularies'
-export { expand } from './expand'
 export { shrink } from './shrink'
 export { expandWithCheck } from './expandWithCheck'
+
+export function expand (prefixed: string): string;
+export function expand (prefixed: string, types: (string | NamedNode)[]): Promise<string>;
+export function expand (prefixed: string, types: (string | NamedNode)[] = []): string | Promise<string> {
+  if (types && types.length) {
+    return expandWithCheck(prefixed, types)
+  }
+
+  return _expand(prefixed)
+}


### PR DESCRIPTION
This is my best attempt to fix #76 

This will not change the API of `import { expand } from '@zazuko/rdf-vocabularies'`

The change is that `@zazuko/rdf-vocabularies/expand` will now not take the second argument and only do simply expansion