### PR TITLE
feat: Add Data Privacy Vocabulary (DPV)

### DIFF
--- a/ontologies/_index.nq
+++ b/ontologies/_index.nq
@@ -65,6 +65,14 @@
 <https://prefix.zazuko.com/doap:> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://usefulinc.com/ns/doap#> .
 <https://prefix.zazuko.com/doap:> <http://www.w3.org/ns/rdfa#prefix> "doap" .
 <https://prefix.zazuko.com/doap:> <http://www.w3.org/ns/rdfa#uri> <http://usefulinc.com/ns/doap#> .
+<https://prefix.zazuko.com/dpv:> <http://dbpedia.org/ontology/filename> "ontologies/dpv.nq" .
+<https://prefix.zazuko.com/dpv:> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/rdfa#PrefixMapping> .
+<https://prefix.zazuko.com/dpv:> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://dpvcg.github.io/dpv/dpv.jsonld> .
+<https://prefix.zazuko.com/dpv:> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://dpvcg.github.io/dpv/dpv.n3> .
+<https://prefix.zazuko.com/dpv:> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://dpvcg.github.io/dpv/dpv.rdf> .
+<https://prefix.zazuko.com/dpv:> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://dpvcg.github.io/dpv/dpv.ttl> .
+<https://prefix.zazuko.com/dpv:> <http://www.w3.org/ns/rdfa#prefix> "dpv" .
+<https://prefix.zazuko.com/dpv:> <http://www.w3.org/ns/rdfa#uri> <http://www.w3.org/ns/dpv#> .
 <https://prefix.zazuko.com/dqv:> <http://dbpedia.org/ontology/filename> "ontologies/dqv.nq" .
 <https://prefix.zazuko.com/dqv:> <http://purl.org/dc/terms/description> "The Data Quality Vocabulary (DQV) is seen as an extension to DCAT to cover the quality of the data, how frequently is it updated, whether it accepts user corrections, persistence commitments etc. When used by publishers, this vocabulary will foster trust in the data amongst developers." .
 <https://prefix.zazuko.com/dqv:> <http://purl.org/dc/terms/title> "Data Quality Vocabulary" .

--- a/ontologies/dpv.nq
+++ b/ontologies/dpv.nq
@@ -1,0 +1,3294 @@
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://purl.org/dc/terms/description> "conduct or assist with research conducted in an academic context e.g. within universities"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://www.w3.org/2000/01/rdf-schema#label> "Academic Research"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/purposes#Education> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AcademicResearch> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Accent> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Accent> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Accent> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Accent> <http://purl.org/dc/terms/description> "Information about an linguistic and speech accents."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Accent> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Accent> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Accent> <http://www.w3.org/2000/01/rdf-schema#label> "Accent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Accent> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Language> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Accent> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://purl.org/dc/terms/description> "conduct or enforce access control"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://www.w3.org/2000/01/rdf-schema#label> "Access Control"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/purposes#Login> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Security> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControl> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://purl.org/dc/terms/description> "Methods which restrict access to a place or resource"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://www.w3.org/2000/01/rdf-schema#label> "Access Control Method"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#TechnicalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccessControlMethod> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccountIdentifier> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccountIdentifier> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccountIdentifier> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccountIdentifier> <http://purl.org/dc/terms/description> "Information about financial account identifier."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccountIdentifier> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccountIdentifier> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccountIdentifier> <http://www.w3.org/2000/01/rdf-schema#label> "Account Identifier"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccountIdentifier> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#FinancialAccount> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AccountIdentifier> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquantaince> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquantaince> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquantaince> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquantaince> <http://purl.org/dc/terms/description> "Information about acquaintainces in a social network."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquantaince> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquantaince> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquantaince> <http://www.w3.org/2000/01/rdf-schema#label> "Acquantaince"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquantaince> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquantaince> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquire> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquire> <http://purl.org/dc/terms/description> "to come into possession or control of the data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquire> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquire> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquire> <http://www.w3.org/2000/01/rdf-schema#label> "Acquire"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquire> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Obtain> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Acquire> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Adapt> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Adapt> <http://purl.org/dc/terms/description> "to modify the data, often rewritten into a new form for a new use"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Adapt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Adapt> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Adapt> <http://www.w3.org/2000/01/rdf-schema#label> "Adapt"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Adapt> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Adapt> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://purl.org/dc/terms/description> "carry out advertising i.e. process or artefact used to call attention to a product, service, etc. through announcements, notices, or other forms of communication."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://www.w3.org/2000/01/rdf-schema#comment> "Advertising is a subset of Marketing. Advertising by itself does not indicate 'personalisation' i.e. personalised ads."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://www.w3.org/2000/01/rdf-schema#label> "Advertising"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Marketing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Advertising> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Age> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Age> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Age> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Age> <http://purl.org/dc/terms/description> "Information about age"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Age> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Age> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Age> <http://www.w3.org/2000/01/rdf-schema#label> "Age"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Age> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Age> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Align> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Align> <http://purl.org/dc/terms/description> "to adjust the data to be in relation to another data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Align> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Align> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Align> <http://www.w3.org/2000/01/rdf-schema#label> "Align"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Align> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Align> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Alter> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Alter> <http://purl.org/dc/terms/description> "to change the data withouth changing it into something else"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Alter> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Alter> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Alter> <http://www.w3.org/2000/01/rdf-schema#label> "Alter"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Alter> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Alter> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Analyse> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Analyse> <http://purl.org/dc/terms/description> "to study or examine the data in detail"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Analyse> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Analyse> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/vocabs/processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Analyse> <http://www.w3.org/2000/01/rdf-schema#label> "Analyse"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Analyse> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/processing#Analyse> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Analyse> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Use> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Analyse> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymise> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymise> <http://purl.org/dc/terms/description> "to irreversibly alter personal data in such a way that a unique data subject can no longer be identified directly or indirectly or in combination with other data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymise> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymise> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/vocabs/processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymise> <http://www.w3.org/2000/01/rdf-schema#label> "Anonymise"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymise> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/processing#Anonymize> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymise> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymise> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://purl.org/dc/terms/description> "Alterting personal data irreversibly such that a data subject can no longer be identified directly or indirectly, either by the data controller alone or in collaboration with any other party"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_5/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://www.w3.org/2000/01/rdf-schema#label> "Anonymization"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PseudoAnonymization> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Anonymization> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ApartmentOwned> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ApartmentOwned> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ApartmentOwned> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ApartmentOwned> <http://purl.org/dc/terms/description> "Information about apartement(s) owned and its history"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ApartmentOwned> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ApartmentOwned> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ApartmentOwned> <http://www.w3.org/2000/01/rdf-schema#label> "Apartment Owned"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ApartmentOwned> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#HouseOwned> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ApartmentOwned> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Association> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Association> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Association> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Association> <http://purl.org/dc/terms/description> "Information about associations in a social network with other individuals, groups, or entities e.g. friend of a friend"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Association> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Association> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Association> <http://www.w3.org/2000/01/rdf-schema#label> "Association"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Association> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Association> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Attitude> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Attitude> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Attitude> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Attitude> <http://purl.org/dc/terms/description> "Information about attitude."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Attitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Attitude> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Attitude> <http://www.w3.org/2000/01/rdf-schema#label> "Attitude"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Attitude> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Attitude> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authenticating> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authenticating> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authenticating> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authenticating> <http://purl.org/dc/terms/description> "Information about authentication and information used for authenticating"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authenticating> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authenticating> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authenticating> <http://www.w3.org/2000/01/rdf-schema#label> "Authenticating"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authenticating> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Internal> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authenticating> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationHistory> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationHistory> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationHistory> <http://purl.org/dc/terms/description> "Information about prior authentication and its outcomes such as login attempts or location."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationHistory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationHistory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationHistory> <http://www.w3.org/2000/01/rdf-schema#label> "Authentication History"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationHistory> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationHistory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://purl.org/dc/terms/description> "Protocols involving validation of identity i.e. authentication of a person or information"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://www.w3.org/2000/01/rdf-schema#label> "Authentication Protocols"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#TechnicalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://purl.org/dc/terms/description> "Procedures for determining authorisation through permission or authority"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://www.w3.org/2000/01/rdf-schema#comment> "non-technical authorisation procedures: How is it described on an organisational level, who gets access to the data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://www.w3.org/2000/01/rdf-schema#label> "Authorisation Procedure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AuthorisationProcedure> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authority> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authority> <http://purl.org/dc/terms/creator> "Georg Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authority> <http://purl.org/dc/terms/creator> "Harshvardhan Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authority> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authority> <http://purl.org/dc/terms/description> "An authority with the power to create or enforce laws, or determine their compliance."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authority> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authority> <http://www.w3.org/2000/01/rdf-schema#label> "Authority"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authority> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Authority> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AutomatedDecisionMaking> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AutomatedDecisionMaking> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AutomatedDecisionMaking> <http://purl.org/dc/terms/creator> "Piero Bonatti" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AutomatedDecisionMaking> <http://purl.org/dc/terms/description> "Processing that involves automated decision making"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AutomatedDecisionMaking> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AutomatedDecisionMaking> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AutomatedDecisionMaking> <http://www.w3.org/2000/01/rdf-schema#label> "Automated Decision Making"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#AutomatedDecisionMaking> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BankAccount> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BankAccount> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BankAccount> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BankAccount> <http://purl.org/dc/terms/description> "Information about bank accounts."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BankAccount> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BankAccount> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BankAccount> <http://www.w3.org/2000/01/rdf-schema#label> "Bank Account"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BankAccount> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#FinancialAccount> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BankAccount> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://purl.org/dc/terms/description> "Information about behavior or activity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/2000/01/rdf-schema#label> "Behavioral"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Activity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#External> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://purl.org/dc/terms/description> "Information about biometrics and biometric characteristics."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://www.w3.org/2000/01/rdf-schema#label> "Biometric"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Biometric> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BloodType> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BloodType> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BloodType> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BloodType> <http://purl.org/dc/terms/description> "Information about blood type."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BloodType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BloodType> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BloodType> <http://www.w3.org/2000/01/rdf-schema#label> "Blood Type"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BloodType> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BloodType> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowserFingerprint> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowserFingerprint> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowserFingerprint> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowserFingerprint> <http://purl.org/dc/terms/description> "Information about the web browser which is used as a 'fingerprint'"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowserFingerprint> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowserFingerprint> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowserFingerprint> <http://www.w3.org/2000/01/rdf-schema#label> "Browser Fingerprint"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowserFingerprint> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowserFingerprint> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://purl.org/dc/terms/description> "Information about browsing behaviour."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://www.w3.org/2000/01/rdf-schema#label> "Browsing Behavior"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#OnlineActivity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingBehavior> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingReferral> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingReferral> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingReferral> <http://purl.org/dc/terms/description> "Information about web browsing referrer or referral, which can be based on location, targeted referrals, direct, organic search, social media or actions, campaigns."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingReferral> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingReferral> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingReferral> <http://www.w3.org/2000/01/rdf-schema#label> "Browsing Referral"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingReferral> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#BrowsingBehaviour> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#BrowsingReferral> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CallLog> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CallLog> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CallLog> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CallLog> <http://purl.org/dc/terms/description> "Information about the calls that an individual has made."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CallLog> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CallLog> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CallLog> <http://www.w3.org/2000/01/rdf-schema#label> "Call Log"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CallLog> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CallLog> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CarOwned> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CarOwned> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CarOwned> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CarOwned> <http://purl.org/dc/terms/description> "Information about cars ownership and ownership history."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CarOwned> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CarOwned> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CarOwned> <http://www.w3.org/2000/01/rdf-schema#label> "Car Owned"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CarOwned> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Ownership> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CarOwned> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://purl.org/dc/terms/description> "Certification mechanisms, seals, and marks for the purpose of demonstrating compliance"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://www.w3.org/2000/01/rdf-schema#label> "Certification"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CertificationSeal> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Certification> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://purl.org/dc/terms/description> "Certifications, seals, and marks indicating compliance to regulations or practices"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://www.w3.org/2000/01/rdf-schema#label> "Certification and Seal"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CertificationSeal> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Character> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Character> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Character> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Character> <http://purl.org/dc/terms/description> "Information about character in the public sphere"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Character> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Character> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Character> <http://www.w3.org/2000/01/rdf-schema#label> "Character"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Character> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Character> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Child> <http://purl.org/dc/terms/created> "2020-11-25"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Child> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Child> <http://purl.org/dc/terms/description> "A 'child' is a natural legal person who is below a certain legal age depending on the legal jurisdiction."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Child> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Child> <http://www.w3.org/2000/01/rdf-schema#comment> "The legality of age defining a child varies by jurisdiction. In addition, 'child' is distinct from a 'minor'. For example, the legal age drinking alcohol can be 21, which makes a person of age 20 a 'minor' in this context. In other cases, 'minor' and 'child' are used interchangeably to refer to a person below some legally defined age."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Child> <http://www.w3.org/2000/01/rdf-schema#label> "Child"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Child> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#DataSubject> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Child> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://purl.org/dc/terms/description> "A set of rules or procedures outlining the norms and practices for conducting activities"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://www.w3.org/2000/01/rdf-schema#label> "Code of Conduct"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CodeOfConduct> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Collect> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Collect> <http://purl.org/dc/terms/description> "to gather data from someone"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Collect> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Collect> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Collect> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/vocabs/processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Collect> <http://www.w3.org/2000/01/rdf-schema#label> "Collect"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Collect> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/processing#Collect> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Collect> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Obtain> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Collect> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Combine> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Combine> <http://purl.org/dc/terms/description> "to join or merge data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Combine> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Combine> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Combine> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/vocabs/processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Combine> <http://www.w3.org/2000/01/rdf-schema#label> "Combine"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Combine> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/processing#Aggregate> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Combine> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Combine> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://purl.org/dc/terms/description> "carry out activities with a commercial interest i.e. of profit or benefit to the Controller"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://www.w3.org/2000/01/rdf-schema#label> "Commercial Interest"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialInterest> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://purl.org/dc/terms/description> "conduct research in a commercial setting e.g. in a company"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://www.w3.org/2000/01/rdf-schema#label> "Commercial Research"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/purposes#Develop> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommercialResearch> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Communication> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Communication> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Communication> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Communication> <http://purl.org/dc/terms/description> "Information communicated from or to an individual"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Communication> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Communication> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Communication> <http://www.w3.org/2000/01/rdf-schema#label> "Communication"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Communication> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Social> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Communication> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationForCustomerCare> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationForCustomerCare> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationForCustomerCare> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationForCustomerCare> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationForCustomerCare> <http://purl.org/dc/terms/description> "communicate with users via email, phone, sms, chat or push messages regarding your requests."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationForCustomerCare> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationForCustomerCare> <http://www.w3.org/2000/01/rdf-schema#label> "Communication for Customer Care"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationForCustomerCare> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CustomerCare> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationForCustomerCare> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://purl.org/dc/terms/description> "Information about communication metadata in the public sphere"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://www.w3.org/2000/01/rdf-schema#label> "Communications Metadata"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Interactive> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CommunicationsMetadata> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Connection> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Connection> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Connection> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Connection> <http://purl.org/dc/terms/description> "Information about and including connections in a social network"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Connection> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Connection> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Connection> <http://www.w3.org/2000/01/rdf-schema#label> "Connection"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Connection> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Connection> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consent> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consent> <http://purl.org/dc/terms/description> "Consent of the data subject regarding processing of their personal data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consent> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consent> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_11/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consent> <http://www.w3.org/2000/01/rdf-schema#label> "Consent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consent> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consult> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consult> <http://purl.org/dc/terms/description> "to consult or query data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consult> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consult> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consult> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/vocabs/processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consult> <http://www.w3.org/2000/01/rdf-schema#label> "Consult"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consult> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/processing#Query> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consult> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Use> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consult> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consultation> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consultation> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consultation> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consultation> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consultation> <http://purl.org/dc/terms/description> "Consultation is a process of receving feedback, advice, or opinion from an external agency"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consultation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consultation> <http://www.w3.org/2000/01/rdf-schema#label> "Consultation"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consultation> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Consultation> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ConsultationWithAuthority> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ConsultationWithAuthority> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ConsultationWithAuthority> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ConsultationWithAuthority> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ConsultationWithAuthority> <http://purl.org/dc/terms/description> "Consultation with an authority or authoritative entity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ConsultationWithAuthority> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ConsultationWithAuthority> <http://www.w3.org/2000/01/rdf-schema#label> "Consultation with Authority"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ConsultationWithAuthority> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Consultation> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ConsultationWithAuthority> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://purl.org/dc/terms/description> "Information about contacts or used for contacting e.g. email address or phone number"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://www.w3.org/2000/01/rdf-schema#label> "Contact"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Physical> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Tracking> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contact> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://purl.org/dc/terms/description> "The 'context' or 'scope' of the purpose, e.g. restriction to a certain business sector"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://www.w3.org/2000/01/rdf-schema#label> "Context"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Context> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://purl.org/dc/terms/description> "Contractual terms governing data handling within the data controller"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://www.w3.org/2000/01/rdf-schema#label> "Contract"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#LegalAgreement> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Contract> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Copy> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Copy> <http://purl.org/dc/terms/description> "to produce an exact reprodution of the data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Copy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Copy> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/vocabs/processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Copy> <http://www.w3.org/2000/01/rdf-schema#label> "Copy"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Copy> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/processing#Copy> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Copy> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Copy> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Country> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Country> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Country> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Country> <http://purl.org/dc/terms/description> "Information about country e.g. residence, travel."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Country> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Country> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Country> <http://www.w3.org/2000/01/rdf-schema#label> "Country"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Country> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Location> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Country> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateEventRecommendations> <http://purl.org/dc/terms/created> "2019-11-26"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateEventRecommendations> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateEventRecommendations> <http://purl.org/dc/terms/creator> "Rudy Jacob" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateEventRecommendations> <http://purl.org/dc/terms/description> "create and provide personalised recommendations for events"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateEventRecommendations> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateEventRecommendations> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateEventRecommendations> <http://www.w3.org/2000/01/rdf-schema#label> "Create Event Recommendations"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateEventRecommendations> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateEventRecommendations> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://purl.org/dc/terms/created> "2019-11-26"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://purl.org/dc/terms/creator> "Rudy Jacob" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://purl.org/dc/terms/description> "create and provide personalised recommendations"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://www.w3.org/2000/01/rdf-schema#label> "Create Personalized Recommendations"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServicePersonalization> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://purl.org/dc/terms/description> "create product recommendations e.g. suggest similar products"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://www.w3.org/2000/01/rdf-schema#label> "Create Product Recommendations"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/purposes#Marketing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CreatePersonalizedRecommendations> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreateProductRecommendations> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Credit> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Credit> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Credit> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Credit> <http://purl.org/dc/terms/description> "Information about reputation with regards to money"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Credit> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Credit> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Credit> <http://www.w3.org/2000/01/rdf-schema#label> "Credit"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Credit> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Credit> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCapacity> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCapacity> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCapacity> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCapacity> <http://purl.org/dc/terms/description> "Information about credit capacity."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCapacity> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCapacity> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCapacity> <http://www.w3.org/2000/01/rdf-schema#label> "Credit Capacity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCapacity> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Credit> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCapacity> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCardNumber> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCardNumber> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCardNumber> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCardNumber> <http://purl.org/dc/terms/description> "Information about credit card number"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCardNumber> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCardNumber> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCardNumber> <http://www.w3.org/2000/01/rdf-schema#label> "Credit Card Number"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCardNumber> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PaymentCardNumber> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditCardNumber> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditRecord> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditRecord> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditRecord> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditRecord> <http://purl.org/dc/terms/description> "Information about credit record."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditRecord> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditRecord> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditRecord> <http://www.w3.org/2000/01/rdf-schema#label> "Credit Record"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditRecord> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Credit> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditRecord> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditScore> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditScore> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditScore> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditScore> <http://purl.org/dc/terms/description> "Information about credit score."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditScore> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditScore> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditScore> <http://www.w3.org/2000/01/rdf-schema#label> "Credit Score"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditScore> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CreditWorthiness> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditScore> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditStanding> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditStanding> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditStanding> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditStanding> <http://purl.org/dc/terms/description> "Information about credit standing."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditStanding> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditStanding> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditStanding> <http://www.w3.org/2000/01/rdf-schema#label> "Credit Standing"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditStanding> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Credit> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditStanding> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditWorthiness> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditWorthiness> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditWorthiness> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditWorthiness> <http://purl.org/dc/terms/description> "Information about credit worthiness."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditWorthiness> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditWorthiness> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditWorthiness> <http://www.w3.org/2000/01/rdf-schema#label> "Credit Worthiness"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditWorthiness> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Credit> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CreditWorthiness> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://purl.org/dc/terms/description> "Information about criminal activity e.g. criminal convictions or jail time"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://www.w3.org/2000/01/rdf-schema#label> "Criminal"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Judicial> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Social> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Criminal> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalCharge> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalCharge> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalCharge> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalCharge> <http://purl.org/dc/terms/description> "Information about criminal charges."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalCharge> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalCharge> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalCharge> <http://www.w3.org/2000/01/rdf-schema#label> "Criminal Charge"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalCharge> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Criminal> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalCharge> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalConviction> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalConviction> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalConviction> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalConviction> <http://purl.org/dc/terms/description> "Information about criminal convictions."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalConviction> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalConviction> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalConviction> <http://www.w3.org/2000/01/rdf-schema#label> "Criminal Conviction"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalConviction> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Criminal> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalConviction> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalPardon> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalPardon> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalPardon> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalPardon> <http://purl.org/dc/terms/description> "Information about criminal pardons."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalPardon> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalPardon> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalPardon> <http://www.w3.org/2000/01/rdf-schema#label> "Criminal Pardon"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalPardon> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Criminal> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CriminalPardon> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://purl.org/dc/terms/description> "provide assistance for customer complaints and satisfaction"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://www.w3.org/2000/01/rdf-schema#label> "Customer Care"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/purposes#Feedback> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServiceProvision> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#CustomerCare> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DNACode> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DNACode> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DNACode> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DNACode> <http://purl.org/dc/terms/description> "Information about DNA."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DNACode> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DNACode> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DNACode> <http://www.w3.org/2000/01/rdf-schema#label> "DNA Code"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DNACode> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DNACode> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://purl.org/dc/terms/description> "A DPIA involves determining the potential and actual impact of processing activities on individuals or groups of individuals"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://www.w3.org/2000/01/rdf-schema#comment> "Top class: Impact Assessment, and DPIA is sub-class"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://www.w3.org/2000/01/rdf-schema#label> "Data Protection Impact Assessment (DPIA)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ImpactAssessment> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DPIA> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://purl.org/dc/terms/description> "The individual or organisation that decides (or controls) the purpose(s) of processing personal data."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://www.w3.org/2000/01/rdf-schema#comment> "The terms 'Controller' is usually the more common form of indicating a Data Controller. In ISO/IEC the term 'PII Controller' is used."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_7/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://www.w3.org/2000/01/rdf-schema#label> "Data Controller"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataController> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProcessor> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProcessor> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProcessor> <http://purl.org/dc/terms/description> "A ‘processor’ means a natural or legal person, public authority, agency or other body which processes personal data on behalf of the controller."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProcessor> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProcessor> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_8/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProcessor> <http://www.w3.org/2000/01/rdf-schema#label> "Data Processor"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProcessor> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProcessor> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionAuthority> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionAuthority> <http://purl.org/dc/terms/creator> "Georg Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionAuthority> <http://purl.org/dc/terms/creator> "Harshvardhan Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionAuthority> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionAuthority> <http://purl.org/dc/terms/description> "An authority tasked with overseeing legal compliance regarding privacy and data protection laws."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionAuthority> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionAuthority> <http://www.w3.org/2000/01/rdf-schema#label> "Data Protection Authority"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionAuthority> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Authority> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionAuthority> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionOfficer> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionOfficer> <http://purl.org/dc/terms/creator> "Georg Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionOfficer> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionOfficer> <http://purl.org/dc/terms/description> "An entity within or authorised by an organisation to monitor internal compliance, inform and advise on your data protection obligations and act as a contact point for data subjects and the supervisory authority."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionOfficer> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionOfficer> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_37/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionOfficer> <http://www.w3.org/2000/01/rdf-schema#label> "Data Protection Officer"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionOfficer> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataProtectionOfficer> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSource> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSource> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSource> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSource> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSource> <http://purl.org/dc/terms/description> "The source or origin of data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSource> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSource> <http://www.w3.org/2000/01/rdf-schema#comment> "Source is direct point of data collection; 'origin' would indicate the original/others points of where the data originates from"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSource> <http://www.w3.org/2000/01/rdf-schema#label> "Data Source"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSource> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubProcessor> <http://purl.org/dc/terms/created> "2020-11-25"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubProcessor> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubProcessor> <http://purl.org/dc/terms/description> "A 'sub-processor' is a processor engaged by another processor"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubProcessor> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubProcessor> <http://www.w3.org/2000/01/rdf-schema#comment> "sub-processor' is a commonly used term similar to 'sub-contractor' and does not have a specific legal definition"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubProcessor> <http://www.w3.org/2000/01/rdf-schema#label> "Data Sub-Processor"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubProcessor> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#DataProcessor> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubProcessor> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://purl.org/dc/terms/description> "The individual (or category of individuals) whose personal data is being processed"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://www.w3.org/2000/01/rdf-schema#comment> "The term 'data subject' is specific to the GDPR, but is functionally equivalent to the term 'individual' and the ISO/IEC term 'PII Principle'."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_1/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://www.w3.org/2000/01/rdf-schema#label> "Data Subject"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubject> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://purl.org/dc/terms/created> "2020-11-18"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://purl.org/dc/terms/creator> "Harshvardhan Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://purl.org/dc/terms/description> "The rights applicable or provided to a Data Subject"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://www.w3.org/2000/01/rdf-schema#comment> "Based on use of definitions, the notion of 'Data Subject Right' can be equivalent to 'Individual Right' or 'Right of a Person'"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://www.w3.org/2000/01/rdf-schema#label> "Data Subject Right"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Right> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DataSubjectRight> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://purl.org/dc/terms/description> "Conversion of identifiable personal data (PII) to un-identifiable personal data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://www.w3.org/2000/01/rdf-schema#label> "De-Identification"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PseudoAnonymization> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeIdentification> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://purl.org/dc/terms/description> "deliver goods and services"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://www.w3.org/2000/01/rdf-schema#label> "Delivery of Goods"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/purposes#Delivery> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#RequestedServiceProvision> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeliveryOfGoods> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demeanor> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demeanor> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demeanor> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demeanor> <http://purl.org/dc/terms/description> "Information about demeanor."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demeanor> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demeanor> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demeanor> <http://www.w3.org/2000/01/rdf-schema#label> "Demeanor"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demeanor> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demeanor> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demographic> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demographic> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demographic> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demographic> <http://purl.org/dc/terms/description> "Information about demography and demographic characteristics"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demographic> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demographic> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demographic> <http://www.w3.org/2000/01/rdf-schema#label> "Demographic"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demographic> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#External> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Demographic> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Derive> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Derive> <http://purl.org/dc/terms/description> "to create new derivative data from the original data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Derive> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Derive> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/vocabs/processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Derive> <http://www.w3.org/2000/01/rdf-schema#label> "Derive"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Derive> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/processing#Derive> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Derive> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Derive> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://purl.org/dc/terms/description> "Derived data is data that is obtained or derived from other data."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://www.w3.org/2000/01/rdf-schema#label> "Derived Personal Data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Derived> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DerivedPersonalData> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://purl.org/dc/terms/description> "A set of rules or guidelines outlining criterias for design"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://www.w3.org/2000/01/rdf-schema#label> "Design Standard"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DesignStandard> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Destruct> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Destruct> <http://purl.org/dc/terms/description> "to process data in a way it no longer exists or cannot be repaired"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Destruct> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Destruct> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Destruct> <http://www.w3.org/2000/01/rdf-schema#label> "Destruct"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Destruct> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Remove> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Destruct> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://purl.org/dc/terms/description> "Information about applications or application-like software on a device."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://www.w3.org/2000/01/rdf-schema#label> "Device Applications"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#DeviceSoftware> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceApplications> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://purl.org/dc/terms/description> "Information about devices"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/2000/01/rdf-schema#label> "Device Based"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Computer> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Tracking> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://purl.org/dc/terms/description> "Information about the operating system (OS) or system software that manages hardware or software resources."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://www.w3.org/2000/01/rdf-schema#label> "Device Operating System"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#DeviceSoftware> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceOperatingSystem> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://purl.org/dc/terms/description> "Information about software on or related to a device."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://www.w3.org/2000/01/rdf-schema#label> "Device Software"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DeviceSoftware> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dialect> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dialect> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dialect> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dialect> <http://purl.org/dc/terms/description> "Information about linguistic dialects."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dialect> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dialect> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dialect> <http://www.w3.org/2000/01/rdf-schema#label> "Dialect"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dialect> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Language> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dialect> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DirectMarketing> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DirectMarketing> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DirectMarketing> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DirectMarketing> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DirectMarketing> <http://purl.org/dc/terms/description> "carry out direct marketing i.e. marketing communicated directly to the individual"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DirectMarketing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DirectMarketing> <http://www.w3.org/2000/01/rdf-schema#label> "Direct Marketing"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DirectMarketing> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Marketing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DirectMarketing> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disability> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disability> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disability> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disability> <http://purl.org/dc/terms/description> "Information about disabilities."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disability> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disability> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disability> <http://www.w3.org/2000/01/rdf-schema#label> "Disability"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disability> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disability> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DisciplinaryAction> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DisciplinaryAction> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DisciplinaryAction> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DisciplinaryAction> <http://purl.org/dc/terms/description> "Information about disciplinary actions and its history"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DisciplinaryAction> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DisciplinaryAction> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DisciplinaryAction> <http://www.w3.org/2000/01/rdf-schema#label> "Disciplinary Action"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DisciplinaryAction> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DisciplinaryAction> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disclose> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disclose> <http://purl.org/dc/terms/description> "to make data known"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/2000/01/rdf-schema#label> "Disclose"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DiscloseByTransmission> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DiscloseByTransmission> <http://purl.org/dc/terms/description> "to disclose data by means of transmission"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DiscloseByTransmission> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DiscloseByTransmission> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DiscloseByTransmission> <http://www.w3.org/2000/01/rdf-schema#label> "Disclose by Transmission"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DiscloseByTransmission> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DiscloseByTransmission> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dislike> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dislike> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dislike> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dislike> <http://purl.org/dc/terms/description> "Information about dislikes or preferences regarding repulsions."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dislike> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dislike> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dislike> <http://www.w3.org/2000/01/rdf-schema#label> "Dislike"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dislike> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Interest> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Dislike> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disseminate> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disseminate> <http://purl.org/dc/terms/description> "to spread data throughout"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disseminate> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disseminate> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disseminate> <http://www.w3.org/2000/01/rdf-schema#label> "Disseminate"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disseminate> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Disseminate> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Divorce> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Divorce> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Divorce> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Divorce> <http://purl.org/dc/terms/description> "Information about divorce(s)."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Divorce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Divorce> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Divorce> <http://www.w3.org/2000/01/rdf-schema#label> "Divorce"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Divorce> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Divorce> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DrugTestResult> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DrugTestResult> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DrugTestResult> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DrugTestResult> <http://purl.org/dc/terms/description> "Information about drug test results."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DrugTestResult> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DrugTestResult> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DrugTestResult> <http://www.w3.org/2000/01/rdf-schema#label> "Drug Test Result"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DrugTestResult> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#DrugTestResult> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailAddress> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailAddress> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailAddress> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailAddress> <http://purl.org/dc/terms/description> "Information about Email address."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailAddress> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailAddress> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailAddress> <http://www.w3.org/2000/01/rdf-schema#label> "Email Address"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailAddress> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Contact> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailAddress> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailContent> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailContent> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailContent> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailContent> <http://purl.org/dc/terms/description> "Information about the contents of Emails sent or recevied"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailContent> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailContent> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailContent> <http://www.w3.org/2000/01/rdf-schema#label> "Email Content"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailContent> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Communication> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmailContent> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmploymentHistory> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmploymentHistory> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmploymentHistory> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmploymentHistory> <http://purl.org/dc/terms/description> "Information about employment history"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmploymentHistory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmploymentHistory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmploymentHistory> <http://www.w3.org/2000/01/rdf-schema#label> "Employment History"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmploymentHistory> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EmploymentHistory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://purl.org/dc/terms/description> "Encryption of data when being stored (persistent encryption)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://www.w3.org/2000/01/rdf-schema#label> "Encryption in Rest"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInRest> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://purl.org/dc/terms/description> "Encryption of data in transit e.g. when being transferred from one location to another, including sharing"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://www.w3.org/2000/01/rdf-schema#label> "Encryption in Transfer"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EncryptionInTransfer> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Erase> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Erase> <http://purl.org/dc/terms/description> "to delete data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Erase> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Erase> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Erase> <http://www.w3.org/2000/01/rdf-schema#label> "Erase"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Erase> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Remove> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Erase> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://purl.org/dc/terms/description> "Information about ethnic origin"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://www.w3.org/2000/01/rdf-schema#label> "Ethnic Origin"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Ethnicity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EthnicOrigin> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ethnicity> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ethnicity> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ethnicity> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ethnicity> <http://purl.org/dc/terms/description> "Information about ethnic origins and lineage"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ethnicity> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ethnicity> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ethnicity> <http://www.w3.org/2000/01/rdf-schema#label> "Ethnicity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ethnicity> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#External> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ethnicity> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EvaluationScoring> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EvaluationScoring> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EvaluationScoring> <http://purl.org/dc/terms/creator> "Piero Bonatti" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EvaluationScoring> <http://purl.org/dc/terms/description> "Processing that involves evaluation and scoring of individuals"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EvaluationScoring> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EvaluationScoring> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EvaluationScoring> <http://www.w3.org/2000/01/rdf-schema#label> "Evaluation and Scoring"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#EvaluationScoring> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#External> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#External> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#External> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#External> <http://purl.org/dc/terms/description> "Information about external characteristics that can be observed"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#External> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#External> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#External> <http://www.w3.org/2000/01/rdf-schema#label> "External"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#External> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#External> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Family> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Family> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Family> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Family> <http://purl.org/dc/terms/description> "Information about family and relationships"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Family> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Family> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Family> <http://www.w3.org/2000/01/rdf-schema#label> "Family"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Family> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Social> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Family> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyHealthHistory> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyHealthHistory> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyHealthHistory> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyHealthHistory> <http://purl.org/dc/terms/description> "Information about family health history."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyHealthHistory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyHealthHistory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyHealthHistory> <http://www.w3.org/2000/01/rdf-schema#label> "Family Health History"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyHealthHistory> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#HealthHistory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyHealthHistory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyStructure> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyStructure> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyStructure> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyStructure> <http://purl.org/dc/terms/description> "Information about family and familial structure."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/2000/01/rdf-schema#label> "Family Structure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Family> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Favorite> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Favorite> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Favorite> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Favorite> <http://purl.org/dc/terms/description> "Information about favorites"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Favorite> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Favorite> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Favorite> <http://www.w3.org/2000/01/rdf-schema#label> "Favorite"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Favorite> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Favorite> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteColor> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteColor> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteColor> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteColor> <http://purl.org/dc/terms/description> "Information about favorite color."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteColor> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteColor> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteColor> <http://www.w3.org/2000/01/rdf-schema#label> "Favorite Color"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteColor> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Favorite> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteColor> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteFood> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteFood> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteFood> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteFood> <http://purl.org/dc/terms/description> "Information about favorite food."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteFood> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteFood> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteFood> <http://www.w3.org/2000/01/rdf-schema#label> "Favorite Food"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteFood> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Favorite> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteFood> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteMusic> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteMusic> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteMusic> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteMusic> <http://purl.org/dc/terms/description> "Information about favorite music."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteMusic> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteMusic> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteMusic> <http://www.w3.org/2000/01/rdf-schema#label> "Favorite Music"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteMusic> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Favorite> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FavoriteMusic> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fetish> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fetish> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fetish> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fetish> <http://purl.org/dc/terms/description> "Information an individual's sexual fetishes"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fetish> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fetish> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fetish> <http://www.w3.org/2000/01/rdf-schema#label> "Fetish"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fetish> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fetish> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://purl.org/dc/terms/description> "Information about finance including monetary characteristics and transactions"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://www.w3.org/2000/01/rdf-schema#label> "Financial"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Financial> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Financial> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccount> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccount> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccount> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccount> <http://purl.org/dc/terms/description> "Information about financial accounts."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccount> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccount> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccount> <http://www.w3.org/2000/01/rdf-schema#label> "Financial Account"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccount> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Financial> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccount> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccountNumber> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccountNumber> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccountNumber> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccountNumber> <http://purl.org/dc/terms/description> "Information about financial account number"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccountNumber> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccountNumber> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccountNumber> <http://www.w3.org/2000/01/rdf-schema#label> "Financial Account Number"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccountNumber> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#AccountIdentifier> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FinancialAccountNumber> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fingerprint> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fingerprint> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fingerprint> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fingerprint> <http://purl.org/dc/terms/description> "Information about fingerprint used for biometric purposes."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fingerprint> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fingerprint> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fingerprint> <http://www.w3.org/2000/01/rdf-schema#label> "Fingerprint"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fingerprint> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Biometric> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Fingerprint> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://purl.org/dc/terms/description> "detect and prevent fraud"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://www.w3.org/2000/01/rdf-schema#label> "Fraud Prevention and Detection"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/purposes#Government> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Security> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#FraudPreventionAndDetection> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Friend> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Friend> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Friend> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Friend> <http://purl.org/dc/terms/description> "Information about friends in a social network, including aspects of friendships such as years together or nature of friendship."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Friend> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Friend> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Friend> <http://www.w3.org/2000/01/rdf-schema#label> "Friend"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Friend> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Friend> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GPSCoordinate> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GPSCoordinate> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GPSCoordinate> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GPSCoordinate> <http://purl.org/dc/terms/description> "Information about location expressed using Global Position System coordinates (GPS)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GPSCoordinate> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GPSCoordinate> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GPSCoordinate> <http://www.w3.org/2000/01/rdf-schema#label> "GPS Coordinate"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GPSCoordinate> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Location> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GPSCoordinate> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Gender> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Gender> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Gender> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Gender> <http://purl.org/dc/terms/description> "Information about gender"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Gender> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Gender> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Gender> <http://www.w3.org/2000/01/rdf-schema#label> "Gender"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Gender> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Gender> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GeneralReputation> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GeneralReputation> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GeneralReputation> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GeneralReputation> <http://purl.org/dc/terms/description> "Information about reputation in the public sphere"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GeneralReputation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GeneralReputation> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GeneralReputation> <http://www.w3.org/2000/01/rdf-schema#label> "General Reputation"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GeneralReputation> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GeneralReputation> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Geographic> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Geographic> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Geographic> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Geographic> <http://purl.org/dc/terms/description> "Information about location or based on geography (e.g., home address)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Geographic> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Geographic> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Geographic> <http://www.w3.org/2000/01/rdf-schema#label> "Geographic"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Geographic> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Demographic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Geographic> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GroupMembership> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GroupMembership> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GroupMembership> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GroupMembership> <http://purl.org/dc/terms/description> "Information about groups and memberships included or associated with in a social network"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GroupMembership> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GroupMembership> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GroupMembership> <http://www.w3.org/2000/01/rdf-schema#label> "Group Membership"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GroupMembership> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GroupMembership> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://purl.org/dc/terms/description> "Guidelines or Principles regarding processing and operational measures"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://www.w3.org/2000/01/rdf-schema#label> "GuidelinesPrinciple"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HairColor> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HairColor> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HairColor> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HairColor> <http://purl.org/dc/terms/description> "Information about hair colour"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HairColor> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HairColor> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HairColor> <http://www.w3.org/2000/01/rdf-schema#label> "Hair Color"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HairColor> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HairColor> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://purl.org/dc/terms/description> "Information about health."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://www.w3.org/2000/01/rdf-schema#label> "Health"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Health> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Health> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthHistory> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthHistory> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthHistory> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthHistory> <http://purl.org/dc/terms/description> "Information about health history."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthHistory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthHistory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthHistory> <http://www.w3.org/2000/01/rdf-schema#label> "Health History"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthHistory> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthHistory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthRecord> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthRecord> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthRecord> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthRecord> <http://purl.org/dc/terms/description> "Information about health record."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthRecord> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthRecord> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthRecord> <http://www.w3.org/2000/01/rdf-schema#label> "Health Record"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthRecord> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HealthRecord> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Height> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Height> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Height> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Height> <http://purl.org/dc/terms/description> "Information about physical height"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Height> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Height> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Height> <http://www.w3.org/2000/01/rdf-schema#label> "Height"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Height> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Height> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Historical> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Historical> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Historical> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Historical> <http://purl.org/dc/terms/description> "Information about historical data related to or relevant regarding history or past events"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Historical> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Historical> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Historical> <http://www.w3.org/2000/01/rdf-schema#label> "Historical"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Historical> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Historical> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HouseOwned> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HouseOwned> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HouseOwned> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HouseOwned> <http://purl.org/dc/terms/description> "Information about house(s) owned and ownership history."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HouseOwned> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HouseOwned> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HouseOwned> <http://www.w3.org/2000/01/rdf-schema#label> "House Owned"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HouseOwned> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Ownership> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#HouseOwned> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IPAddress> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IPAddress> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IPAddress> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IPAddress> <http://purl.org/dc/terms/description> "Information about the Internet protocol (IP) address of a device"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IPAddress> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IPAddress> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IPAddress> <http://www.w3.org/2000/01/rdf-schema#label> "IP Address"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IPAddress> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IPAddress> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Identifying> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Identifying> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Identifying> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Identifying> <http://purl.org/dc/terms/description> "Information that uniquely or semi-uniquely identifies an individual or a group"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/2000/01/rdf-schema#label> "Identifying"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#External> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://purl.org/dc/terms/description> "verify and authorise identity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://www.w3.org/2000/01/rdf-schema#label> "Identity Verification"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Security> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IdentityVerification> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImpactAssessment> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImpactAssessment> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImpactAssessment> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImpactAssessment> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImpactAssessment> <http://purl.org/dc/terms/description> "Calculating or determining the likelihood of impact of an existing or proposed process, which can involve risks or detriments."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImpactAssessment> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImpactAssessment> <http://www.w3.org/2000/01/rdf-schema#label> "Impact Assessment"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImpactAssessment> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImpactAssessment> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://purl.org/dc/terms/description> "improve existing products and services"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://www.w3.org/2000/01/rdf-schema#label> "Improve Existing Products and Services"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OptimisationForController> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveExistingProductsAndServices> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://purl.org/dc/terms/description> "improve customer-relationship management (CRM) processes"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://www.w3.org/2000/01/rdf-schema#label> "Improve Internal CRM Processes"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OptimisationForController> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ImproveInternalCRMProcesses> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Income> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Income> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Income> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Income> <http://purl.org/dc/terms/description> "Information about financial income e.g. for individual or household or family"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Income> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Income> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Income> <http://www.w3.org/2000/01/rdf-schema#label> "Income"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Income> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Income> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncomeBracket> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncomeBracket> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncomeBracket> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncomeBracket> <http://purl.org/dc/terms/description> "Information about income bracket."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncomeBracket> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncomeBracket> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncomeBracket> <http://www.w3.org/2000/01/rdf-schema#label> "Income Bracket"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncomeBracket> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Demographic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncomeBracket> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://purl.org/dc/terms/description> "improve the robustness and resilience of services"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://www.w3.org/2000/01/rdf-schema#label> "Increase Service Robustness"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OptimisationForController> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IncreaseServiceRobustness> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IndividualHealthHistory> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IndividualHealthHistory> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IndividualHealthHistory> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IndividualHealthHistory> <http://purl.org/dc/terms/description> "Information about information health history."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IndividualHealthHistory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IndividualHealthHistory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IndividualHealthHistory> <http://www.w3.org/2000/01/rdf-schema#label> "Individual Health History"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IndividualHealthHistory> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#HealthHistory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#IndividualHealthHistory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InnovativeUseOfNewTechnologies> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InnovativeUseOfNewTechnologies> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InnovativeUseOfNewTechnologies> <http://purl.org/dc/terms/creator> "Piero Bonatti" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InnovativeUseOfNewTechnologies> <http://purl.org/dc/terms/description> "Processing that involves use of innovative and new technologies"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InnovativeUseOfNewTechnologies> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InnovativeUseOfNewTechnologies> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InnovativeUseOfNewTechnologies> <http://www.w3.org/2000/01/rdf-schema#label> "Innovative Use of New Technologies"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InnovativeUseOfNewTechnologies> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Intention> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Intention> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Intention> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Intention> <http://purl.org/dc/terms/description> "Information about intentions"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Intention> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Intention> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Intention> <http://www.w3.org/2000/01/rdf-schema#label> "Intention"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Intention> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Intention> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interaction> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interaction> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interaction> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interaction> <http://purl.org/dc/terms/description> "Information about interactions in the public sphere"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interaction> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interaction> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interaction> <http://www.w3.org/2000/01/rdf-schema#label> "Interaction"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interaction> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interaction> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interest> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interest> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interest> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interest> <http://purl.org/dc/terms/description> "Information about interests"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interest> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interest> <http://www.w3.org/2000/01/rdf-schema#label> "Interest"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interest> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Interest> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Internal> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Internal> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Internal> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Internal> <http://purl.org/dc/terms/description> "Informatoin about internal characteristics that cannot be seen or observed"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Internal> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Internal> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Internal> <http://www.w3.org/2000/01/rdf-schema#label> "Internal"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Internal> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Internal> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://purl.org/dc/terms/description> "optimise internal resources used by the organisation e.g. resource usage"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://www.w3.org/2000/01/rdf-schema#label> "Internal Resource Optimisation"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OptimisationForController> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#InternalResourceOptimisation> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Job> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Job> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Job> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Job> <http://purl.org/dc/terms/description> "Information about professional jobs"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Job> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Job> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Job> <http://www.w3.org/2000/01/rdf-schema#label> "Job"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Job> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Job> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#KnowledgeBelief> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#KnowledgeBelief> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#KnowledgeBelief> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#KnowledgeBelief> <http://purl.org/dc/terms/description> "Information about knowledge and beliefs"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#KnowledgeBelief> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#KnowledgeBelief> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#KnowledgeBelief> <http://www.w3.org/2000/01/rdf-schema#label> "Knowledge and Beliefs"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#KnowledgeBelief> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Internal> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#KnowledgeBelief> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Language> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Language> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Language> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Language> <http://purl.org/dc/terms/description> "Information about language and lingual history."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Language> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Language> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Language> <http://www.w3.org/2000/01/rdf-schema#label> "Language"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Language> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Ethnicity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Language> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LargeScaleProcessing> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LargeScaleProcessing> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LargeScaleProcessing> <http://purl.org/dc/terms/creator> "Piero Bonatti" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LargeScaleProcessing> <http://purl.org/dc/terms/description> "Processing that takes place at large scales"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LargeScaleProcessing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LargeScaleProcessing> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LargeScaleProcessing> <http://www.w3.org/2000/01/rdf-schema#label> "Large Scale Processing"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LargeScaleProcessing> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://purl.org/dc/terms/description> "A legally binding agreement"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://www.w3.org/2000/01/rdf-schema#label> "Legal Agreement"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalAgreement> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalBasis> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalBasis> <http://purl.org/dc/terms/description> "The Legal basis used to justify processing of personal data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalBasis> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalBasis> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalBasis> <http://www.w3.org/2000/01/rdf-schema#comment> "Legal basis (plural: legal bases) are defined by legislations and regulations, whose applicability is usually restricted to specific jurisdictions."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalBasis> <http://www.w3.org/2000/01/rdf-schema#label> "Legal Basis"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalBasis> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalCompliance> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalCompliance> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalCompliance> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalCompliance> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalCompliance> <http://purl.org/dc/terms/description> "fulfil obligations or requirements towards achieving compliance with law or regulations."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalCompliance> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalCompliance> <http://www.w3.org/2000/01/rdf-schema#label> "Legal Compliance"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalCompliance> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalCompliance> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalEntity> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalEntity> <http://purl.org/dc/terms/description> "A human or non-human that constitute as a legally defined entity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/2000/01/rdf-schema#label> "Legal Entity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LifeHistory> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LifeHistory> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LifeHistory> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LifeHistory> <http://purl.org/dc/terms/description> "Information about personal history regarding events or activities - including  their occurences that might be directly related or have had an influence (e.g. World War, 9/11)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LifeHistory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LifeHistory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LifeHistory> <http://www.w3.org/2000/01/rdf-schema#label> "Life History"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LifeHistory> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Historical> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LifeHistory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Like> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Like> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Like> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Like> <http://purl.org/dc/terms/description> "Information about likes or preferences regarding attractions."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Like> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Like> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Like> <http://www.w3.org/2000/01/rdf-schema#label> "Like"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Like> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Interest> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Like> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://purl.org/dc/terms/description> "Information about the links that an individual has clicked."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://www.w3.org/2000/01/rdf-schema#label> "LinkClicked"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Navigation> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LinkClicked> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LoanRecord> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LoanRecord> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LoanRecord> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LoanRecord> <http://purl.org/dc/terms/description> "Information about loans, whether applied, provided or rejected, and its history"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LoanRecord> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LoanRecord> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LoanRecord> <http://www.w3.org/2000/01/rdf-schema#label> "Loan Record"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LoanRecord> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#LoanRecord> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://purl.org/dc/terms/description> "Information about location"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://www.w3.org/2000/01/rdf-schema#label> "Location"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Location> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Tracking> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Location> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MACAddress> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MACAddress> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MACAddress> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MACAddress> <http://purl.org/dc/terms/description> "Information about the Media Access Control (MAC) address of a device"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MACAddress> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MACAddress> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MACAddress> <http://www.w3.org/2000/01/rdf-schema#label> "MAC Address"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MACAddress> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#DeviceBased> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MACAddress> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MakeAvailable> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MakeAvailable> <http://purl.org/dc/terms/description> "to transform or publish data to be used"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MakeAvailable> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MakeAvailable> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MakeAvailable> <http://www.w3.org/2000/01/rdf-schema#label> "Make Available"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MakeAvailable> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MakeAvailable> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MaritalStatus> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MaritalStatus> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MaritalStatus> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MaritalStatus> <http://purl.org/dc/terms/description> "Information about marital status and history"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MaritalStatus> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MaritalStatus> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MaritalStatus> <http://www.w3.org/2000/01/rdf-schema#label> "Marital Status"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MaritalStatus> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MaritalStatus> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marketing> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marketing> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marketing> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marketing> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marketing> <http://purl.org/dc/terms/description> "carry out marketing i.e. promoting, selling, and distributing a product or service"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marketing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marketing> <http://www.w3.org/2000/01/rdf-schema#label> "Marketing"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marketing> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CommercialInterest> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marketing> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marriage> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marriage> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marriage> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marriage> <http://purl.org/dc/terms/description> "Information about marriage(s)."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marriage> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marriage> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marriage> <http://www.w3.org/2000/01/rdf-schema#label> "Marriage"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marriage> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Marriage> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MatchingCombining> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MatchingCombining> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MatchingCombining> <http://purl.org/dc/terms/creator> "Piero Bonatti" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MatchingCombining> <http://purl.org/dc/terms/description> "Processing that involves matching and combining of personal data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MatchingCombining> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MatchingCombining> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MatchingCombining> <http://www.w3.org/2000/01/rdf-schema#label> "Matching and Combining"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MatchingCombining> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://purl.org/dc/terms/description> "Information about health, medical conditions or health care"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/2000/01/rdf-schema#label> "MedicalHealth"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#External> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MentalHealth> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MentalHealth> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MentalHealth> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MentalHealth> <http://purl.org/dc/terms/description> "Information about mental health."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MentalHealth> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MentalHealth> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MentalHealth> <http://www.w3.org/2000/01/rdf-schema#label> "Mental Health"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MentalHealth> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Health> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#MentalHealth> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Move> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Move> <http://purl.org/dc/terms/description> "to move data from one location to another including deleting the original copy"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Move> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Move> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/vocabs/processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Move> <http://www.w3.org/2000/01/rdf-schema#label> "Move"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Move> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/processing#Move> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Move> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transfer> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Move> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://purl.org/dc/terms/description> "Non-disclosure Agreements e.g. preserving confidentiality of information"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://www.w3.org/2000/01/rdf-schema#label> "Non-Disclosure Agreement (NDA)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#LegalAgreement> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NDA> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Name> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Name> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Name> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Name> <http://purl.org/dc/terms/description> "Information about names associated or used as given name or nickname."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Name> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Name> <http://www.w3.org/2000/01/rdf-schema#label> "Name"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Name> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Name> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://purl.org/dc/terms/description> "conduct research in a non-commercial setting e.g. for a non-profit-organisation (NGO)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://www.w3.org/2000/01/rdf-schema#label> "Non-Commercial Research"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#NonCommercialResearch> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Obtain> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Obtain> <http://purl.org/dc/terms/description> "to solicit or gather data from someone"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Obtain> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Obtain> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Obtain> <http://www.w3.org/2000/01/rdf-schema#label> "Obtain"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Obtain> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Obtain> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://purl.org/dc/terms/description> "Information about an official identifier or identification document"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://www.w3.org/2000/01/rdf-schema#label> "Official ID"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Government> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OfficialID> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Offspring> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Offspring> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Offspring> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Offspring> <http://purl.org/dc/terms/description> "Information about offspring(s)."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Offspring> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Offspring> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Offspring> <http://www.w3.org/2000/01/rdf-schema#label> "Offspring"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Offspring> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Offspring> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Opinion> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Opinion> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Opinion> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Opinion> <http://purl.org/dc/terms/description> "Information about opinions"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Opinion> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Opinion> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Opinion> <http://www.w3.org/2000/01/rdf-schema#label> "Opinion"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Opinion> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Opinion> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://purl.org/dc/terms/description> "optimise activities and services for the consumer or user"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://www.w3.org/2000/01/rdf-schema#label> "Optimisation for Consumer"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/purposes#Custom> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServiceOptimization> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://purl.org/dc/terms/description> "optimise activities and services for the Controller"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://www.w3.org/2000/01/rdf-schema#label> "Optimisation for Controller"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServiceOptimization> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimisationForController> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://purl.org/dc/terms/description> "optimise interfaces presented to the user"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://www.w3.org/2000/01/rdf-schema#label> "Optimise User Interface"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OptimisationForConsumer> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OptimiseUserInterface> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://purl.org/dc/terms/description> "Organisational measures required/followed when processing data of the declared category"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/2000/01/rdf-schema#label> "Organisational Measure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Organise> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Organise> <http://purl.org/dc/terms/description> "to organize data for arranging or classifying"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Organise> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Organise> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Organise> <http://www.w3.org/2000/01/rdf-schema#label> "Organise"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Organise> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Organise> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ownership> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ownership> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ownership> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ownership> <http://purl.org/dc/terms/description> "Information about ownership and history, including renting, borrowing, possessions."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ownership> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ownership> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ownership> <http://www.w3.org/2000/01/rdf-schema#label> "Ownership"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ownership> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Financial> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Ownership> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PIA> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PIA> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PIA> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PIA> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PIA> <http://purl.org/dc/terms/description> "Carrying out an impact assessment regarding privacy risks"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PIA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PIA> <http://www.w3.org/2000/01/rdf-schema#label> "Privacy Impact Assessment"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PIA> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ImpactAssessment> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PIA> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PINCode> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PINCode> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PINCode> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PINCode> <http://purl.org/dc/terms/description> "Information about Personal identification number (PIN), which is usually used in the process of authenticating the individual as a user accessing a system."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PINCode> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PINCode> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PINCode> <http://www.w3.org/2000/01/rdf-schema#label> "PIN Code"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PINCode> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Authenticating> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PINCode> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Parent> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Parent> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Parent> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Parent> <http://purl.org/dc/terms/description> "Information about parent(s)."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Parent> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Parent> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Parent> <http://www.w3.org/2000/01/rdf-schema#label> "Parent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Parent> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Parent> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Password> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Password> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Password> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Password> <http://purl.org/dc/terms/description> "Information about password used in the process of authenticating the individual as a user accessing a system."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Password> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Password> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Password> <http://www.w3.org/2000/01/rdf-schema#label> "Password"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Password> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Authenticating> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Password> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Payment> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Payment> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Payment> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Payment> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Payment> <http://purl.org/dc/terms/description> "process users’ payment transactions."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Payment> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Payment> <http://www.w3.org/2000/01/rdf-schema#label> "Payment"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Payment> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServiceProvision> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Payment> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCard> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCard> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCard> <http://purl.org/dc/terms/description> "Information about payment card such as Credit Card, Debit Card."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCard> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCard> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCard> <http://www.w3.org/2000/01/rdf-schema#label> "Payment Card"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCard> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#FinancialAccount> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCard> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardExpiry> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardExpiry> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardExpiry> <http://purl.org/dc/terms/description> "Information about payment card expiry such as a date."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardExpiry> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardExpiry> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardExpiry> <http://www.w3.org/2000/01/rdf-schema#label> "Payment Card Expiry"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardExpiry> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PaymentCard> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardExpiry> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardNumber> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardNumber> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardNumber> <http://purl.org/dc/terms/description> "Information about payment card number."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardNumber> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardNumber> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardNumber> <http://www.w3.org/2000/01/rdf-schema#label> "Payment Card Number"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardNumber> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#AccountIdentifier> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardNumber> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PaymentCard> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PaymentCardNumber> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://purl.org/dc/terms/creator> "Harshvardhan Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://purl.org/dc/terms/description> "A category of personal data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/2000/01/rdf-schema#comment> "For a formal legal definition of personal data, see GDPR Art.4-1. An informal definition consists of any data directly or indirectly associated or related to an individual. This definition is equivalent to ISO/IEC definition of Personally Identifiable Information (PII)."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_1/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/2000/01/rdf-schema#label> "Personal Data Category"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/langs/usage-policy#AnyData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataHandling> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataHandling> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataHandling> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataHandling> <http://purl.org/dc/terms/description> "A high-level Class to describe 'data handling'. This can consist of personal data being processed for a purpose, involving entities, using technical and organisational, applicable risks, rights, and legal basis."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataHandling> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataHandling> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataHandling> <http://www.w3.org/2000/01/rdf-schema#label> "Personal Data Handling"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalDataHandling> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalPossession> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalPossession> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalPossession> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalPossession> <http://purl.org/dc/terms/description> "Information about personal possessions."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalPossession> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalPossession> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalPossession> <http://www.w3.org/2000/01/rdf-schema#label> "Personal Possession"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalPossession> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Ownership> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalPossession> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://purl.org/dc/terms/description> "provide personalised advertising"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://www.w3.org/2000/01/rdf-schema#label> "Personalised Advertising"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Advertising> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServicePersonalization> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedAdvertising> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://purl.org/dc/terms/description> "personalise benefits received by the user"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://www.w3.org/2000/01/rdf-schema#label> "Personalised Benefits"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServicePersonalization> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PersonalisedBenefits> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Personality> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Personality> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Personality> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Personality> <http://purl.org/dc/terms/description> "Information about personality (e.g., categorization in terms of the Big Five personality traits)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Personality> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Personality> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Personality> <http://www.w3.org/2000/01/rdf-schema#label> "Personality"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Personality> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Personality> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://purl.org/dc/terms/description> "Information about philosophical beliefs."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://www.w3.org/2000/01/rdf-schema#label> "Philosophical Belief"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#KnowledgeBelief> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhilosophicalBelief> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalAddress> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalAddress> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalAddress> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalAddress> <http://purl.org/dc/terms/description> "Information about physical address."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalAddress> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalAddress> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalAddress> <http://www.w3.org/2000/01/rdf-schema#label> "Physical Address"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalAddress> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Contact> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalAddress> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://purl.org/dc/terms/description> "Information about physical characteristics"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/2000/01/rdf-schema#label> "PhysicalCharacteristic"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Demographic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#External> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalHealth> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalHealth> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalHealth> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalHealth> <http://purl.org/dc/terms/description> "Information about physical health."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalHealth> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalHealth> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalHealth> <http://www.w3.org/2000/01/rdf-schema#label> "Physical Health"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalHealth> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Health> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalHealth> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalTrait> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalTrait> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalTrait> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalTrait> <http://purl.org/dc/terms/description> "Information about defining traits or features regarding the body."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalTrait> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalTrait> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalTrait> <http://www.w3.org/2000/01/rdf-schema#label> "Physical Trait"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalTrait> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Demographic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PhysicalTrait> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Picture> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Picture> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Picture> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Picture> <http://purl.org/dc/terms/description> "Information about visual representation or image e.g. profile photo."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Picture> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Picture> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Picture> <http://www.w3.org/2000/01/rdf-schema#label> "Picture"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Picture> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Picture> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Piercing> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Piercing> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Piercing> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Piercing> <http://purl.org/dc/terms/description> "Information about piercings"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Piercing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Piercing> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Piercing> <http://www.w3.org/2000/01/rdf-schema#label> "Piercing"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Piercing> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Piercing> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://purl.org/dc/terms/description> "Information about political affiliation and history"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "Political Affiliation"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Political> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PoliticalAffiliation> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://purl.org/dc/terms/description> "Information about preferences or interests"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/2000/01/rdf-schema#label> "Preference"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Preference> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Internal> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Prescription> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Prescription> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Prescription> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Prescription> <http://purl.org/dc/terms/description> "Information about medical and pharmaceutical prescriptions"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Prescription> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Prescription> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Prescription> <http://www.w3.org/2000/01/rdf-schema#label> "Prescription"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Prescription> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#MedicalHealth> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Prescription> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://purl.org/dc/terms/description> "Practices regarding selecting appropriate data protection and privacy measures as the 'default' in an activity or service"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://www.w3.org/2000/01/rdf-schema#label> "Privacy by Default"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#GuidelinesPrinciple> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDefault> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://purl.org/dc/terms/description> "Practices regarding incorporating data protection and privacy in the design of information and services"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://www.w3.org/2000/01/rdf-schema#label> "Privacy by Design"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyByDesign> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyPreference> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyPreference> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyPreference> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyPreference> <http://purl.org/dc/terms/description> "Information about privacy preferences"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyPreference> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyPreference> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyPreference> <http://www.w3.org/2000/01/rdf-schema#label> "Privacy Preference"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyPreference> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Preference> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PrivacyPreference> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://purl.org/dc/terms/description> "The processing performed on personal data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/2000/01/rdf-schema#label> "Processing"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/langs/usage-policy#AnyProcessing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Proclivitie> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Proclivitie> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Proclivitie> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Proclivitie> <http://purl.org/dc/terms/description> "Information about proclivities in a sexual context"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Proclivitie> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Proclivitie> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Proclivitie> <http://www.w3.org/2000/01/rdf-schema#label> "Proclivitie"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Proclivitie> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Proclivitie> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Professional> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Professional> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Professional> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Professional> <http://purl.org/dc/terms/description> "Information about educational or professional career"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/2000/01/rdf-schema#label> "Professional"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Social> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalCertification> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalCertification> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalCertification> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalCertification> <http://purl.org/dc/terms/description> "Information about professional certifications"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalCertification> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalCertification> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalCertification> <http://www.w3.org/2000/01/rdf-schema#label> "Professional Certification"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalCertification> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalCertification> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalEvaluation> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalEvaluation> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalEvaluation> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalEvaluation> <http://purl.org/dc/terms/description> "Information about professional evaluations"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalEvaluation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalEvaluation> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalEvaluation> <http://www.w3.org/2000/01/rdf-schema#label> "Professional Evaluation"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalEvaluation> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalEvaluation> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalInterview> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalInterview> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalInterview> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalInterview> <http://purl.org/dc/terms/description> "Information about professional interviews"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalInterview> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalInterview> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalInterview> <http://www.w3.org/2000/01/rdf-schema#label> "Professional Interview"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalInterview> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ProfessionalInterview> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Profiling> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Profiling> <http://purl.org/dc/terms/description> "to create a profile that describes or represents a person"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Profiling> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Profiling> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Profiling> <http://www.w3.org/2000/01/rdf-schema#label> "Profiling"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Profiling> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Use> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Profiling> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymise> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymise> <http://purl.org/dc/terms/description> "to replace personal identifiable information by artificial identifiers"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymise> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymise> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymise> <http://www.w3.org/2000/01/rdf-schema#label> "Pseudo-Anonymise"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymise> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymise> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://purl.org/dc/terms/description> "PseudoAnonmyization or 'pseudonymisation’ means the processing of personal data in such a manner that the personal data can no longer be attributed to a specific data subject without the use of additional information, provided that such additional information is kept separately and is subject to technical and organisational measures to ensure that the personal data are not attributed to an identified or identifiable natural person;"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_5/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://www.w3.org/2000/01/rdf-schema#label> "Pseudo-Anonymization"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudoAnonymization> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://purl.org/dc/terms/description> "Technical measures consisting of pseudoanonymization and encryption"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://www.w3.org/2000/01/rdf-schema#label> "Pseudonymisation and Encryption"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#TechnicalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PseudonymisationEncryption> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PublicLife> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PublicLife> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PublicLife> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PublicLife> <http://purl.org/dc/terms/description> "Information about public life"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/2000/01/rdf-schema#label> "Public Life"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Social> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://purl.org/dc/terms/description> "Information about purchases such as items bought e.g. grocery or clothing"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://www.w3.org/2000/01/rdf-schema#label> "Purchase"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Purchase> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purchase> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PurchasesAndSpendingHabit> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PurchasesAndSpendingHabit> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PurchasesAndSpendingHabit> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PurchasesAndSpendingHabit> <http://purl.org/dc/terms/description> "Information about analysis of purchases made and money spent expressed as a habit e.g. monthly shopping trends"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PurchasesAndSpendingHabit> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PurchasesAndSpendingHabit> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PurchasesAndSpendingHabit> <http://www.w3.org/2000/01/rdf-schema#label> "Purchases and Spending Habit"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PurchasesAndSpendingHabit> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#PurchasesAndSpendingHabit> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://purl.org/dc/terms/description> "The purpose of processing personal data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/2000/01/rdf-schema#label> "Purpose"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/langs/usage-policy#AnyPurpose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://purl.org/dc/terms/description> "Information about race or recial history."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://www.w3.org/2000/01/rdf-schema#label> "Race"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Ethnicity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Race> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://purl.org/dc/terms/description> "Entities that receive personal data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/2000/01/rdf-schema#comment> "A recipient of personal data can be used to indicate any entity that receives personal data. This can be a Third Party, Processor (GDPR), or even a Controller."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_9/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/2000/01/rdf-schema#label> "Recipient"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/langs/usage-policy#AnyRecipient> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Record> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Record> <http://purl.org/dc/terms/description> "to make a record (especially media)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Record> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Record> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Record> <http://www.w3.org/2000/01/rdf-schema#label> "Record"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Record> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Obtain> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Record> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Reference> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Reference> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Reference> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Reference> <http://purl.org/dc/terms/description> "Information about references in the professional context"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Reference> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Reference> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Reference> <http://www.w3.org/2000/01/rdf-schema#label> "Reference"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Reference> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Reference> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegistrationAuthentication> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegistrationAuthentication> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegistrationAuthentication> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegistrationAuthentication> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegistrationAuthentication> <http://purl.org/dc/terms/description> "register, authenticate, and identify in context of a service."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegistrationAuthentication> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegistrationAuthentication> <http://www.w3.org/2000/01/rdf-schema#label> "Registration and Authentication"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegistrationAuthentication> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServiceProvision> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegistrationAuthentication> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://purl.org/dc/terms/description> "Policy regarding repetition or renewal of existing certification(s)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://www.w3.org/2000/01/rdf-schema#label> "Regularity of Re-certification"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RegularityOfRecertification> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Relationship> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Relationship> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Relationship> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Relationship> <http://purl.org/dc/terms/description> "Information about relationships and relationship history."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Relationship> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Relationship> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Relationship> <http://www.w3.org/2000/01/rdf-schema#label> "Relationship"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Relationship> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Family> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Relationship> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://purl.org/dc/terms/description> "Information about religion, religious inclinations, and religious history."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://www.w3.org/2000/01/rdf-schema#label> "Religion"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Religion> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://purl.org/dc/terms/description> "Information about religion and religious beliefs."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://www.w3.org/2000/01/rdf-schema#label> "Religious Belief"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#KnowledgeBelief> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ReligiousBelief> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Remove> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Remove> <http://purl.org/dc/terms/description> "to destruct or erase data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Remove> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Remove> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Remove> <http://www.w3.org/2000/01/rdf-schema#label> "Remove"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Remove> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Remove> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://purl.org/dc/terms/creator> "Georg Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://purl.org/dc/terms/description> "A representative of a legal entity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_27/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://www.w3.org/2000/01/rdf-schema#label> "Representative"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Representative> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://purl.org/dc/terms/description> "conduct research and development for new methods, products, or services"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://www.w3.org/2000/01/rdf-schema#label> "Research and Development"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ResearchAndDevelopment> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Restrict> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Restrict> <http://purl.org/dc/terms/description> "to apply a restriction on the processsing of specific records"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Restrict> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Restrict> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Restrict> <http://www.w3.org/2000/01/rdf-schema#label> "Restrict"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Restrict> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Restrict> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retina> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retina> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retina> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retina> <http://purl.org/dc/terms/description> "Information about retina and the retinal patterns."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retina> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retina> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retina> <http://www.w3.org/2000/01/rdf-schema#label> "Retina"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retina> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Biometric> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retina> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retrieve> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retrieve> <http://purl.org/dc/terms/description> "to retrieve data, often in an automated manner"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retrieve> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retrieve> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retrieve> <http://www.w3.org/2000/01/rdf-schema#label> "Retrieve"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retrieve> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Use> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Retrieve> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Right> <http://purl.org/dc/terms/created> "2020-11-18"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Right> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Right> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Right> <http://purl.org/dc/terms/creator> "Harshvardhan J Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Right> <http://purl.org/dc/terms/description> "The right(s) applicable, provided, or expected."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Right> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Right> <http://www.w3.org/2000/01/rdf-schema#comment> "A 'right' is a legal, social, or ethical principle of freedom or entitlement which dictate the norms regarding what is allowed or owed.. Rights as a concept encompass a broad area of norms and entities, and are not specific to Individuals or Data Protection / Privacy. For individual specific rights, see dpv:DataSubjectRight"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Right> <http://www.w3.org/2000/01/rdf-schema#label> "Right"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Right> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Risk> <http://purl.org/dc/terms/created> "2020-11-18"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Risk> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Risk> <http://purl.org/dc/terms/description> "A risk or possibility or uncertainty of negative effects, impacts, or consequences."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Risk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Risk> <http://www.w3.org/2000/01/rdf-schema#comment> "Risks can be associated with one or more different concepts such as purpose, processing, personal data, technical or organisational measure."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Risk> <http://www.w3.org/2000/01/rdf-schema#label> "Risk"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Risk> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://purl.org/dc/terms/description> "Risk management refers to a coordinated set of activities and methods that is used to direct an organization and to control the many risks that can affect its ability to achieve objectives.  The term risk management also refers to the programme that is used to manage risk. This programme includes risk management principles, a risk management framework, and a risk management process."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://www.w3.org/2000/01/rdf-schema#comment> "Data Protection Impact Assessments as per GDPR art 35, other Privacy Impact Assessments, threat severity assessment https://www.cnil.fr/en/privacy-impact-assessment-pia"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.iso.org/iso-31000-risk-management.html> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://www.w3.org/2000/01/rdf-schema#label> "Risk Management Procedure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#OrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskMitigationMeasure> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskMitigationMeasure> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskMitigationMeasure> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskMitigationMeasure> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskMitigationMeasure> <http://purl.org/dc/terms/description> "Measures intended to mitigate, minimise, or prevent risk."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskMitigationMeasure> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskMitigationMeasure> <http://www.w3.org/2000/01/rdf-schema#label> "Risk Mitigation Measure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskMitigationMeasure> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RiskMitigationMeasure> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RoomNumber> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RoomNumber> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RoomNumber> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RoomNumber> <http://purl.org/dc/terms/description> "Information about location expressed as Room number or similar numbering systems"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RoomNumber> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RoomNumber> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RoomNumber> <http://www.w3.org/2000/01/rdf-schema#label> "Room Number"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RoomNumber> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Location> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#RoomNumber> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Salary> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Salary> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Salary> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Salary> <http://purl.org/dc/terms/description> "Information about salary"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Salary> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Salary> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Salary> <http://www.w3.org/2000/01/rdf-schema#label> "Salary"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Salary> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Salary> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sale> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sale> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sale> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sale> <http://purl.org/dc/terms/description> "Information about sales e.g. selling of goods or services"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sale> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sale> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sale> <http://www.w3.org/2000/01/rdf-schema#label> "Sale"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sale> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sale> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#School> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#School> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#School> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#School> <http://purl.org/dc/terms/description> "Information about school such as name of school, conduct, or grades obtained."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#School> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#School> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#School> <http://www.w3.org/2000/01/rdf-schema#label> "School"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#School> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#School> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://purl.org/dc/terms/description> "A seal or a mark indicating proof of certification to some certification or standard"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://www.w3.org/2000/01/rdf-schema#label> "Seal"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CertificationSeal> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Seal> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SecretText> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SecretText> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SecretText> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SecretText> <http://purl.org/dc/terms/description> "Information about secret text used in the process of authenticating the individual as a user accessing a system, e.g., when recovering a lost password."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SecretText> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SecretText> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SecretText> <http://www.w3.org/2000/01/rdf-schema#label> "Secret Text"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SecretText> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Authenticating> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SecretText> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://purl.org/dc/terms/description> "The 'sector' or 'domain' of a purpose e.g. Agriculture, Advertising"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://www.w3.org/2000/01/rdf-schema#comment> "There are various sector codes used commonly to indicate the domain of an organisation or business. Examples include NACE (EU), ISIC (UN), SIC and NAICS (USA)."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://www.w3.org/2000/01/rdf-schema#label> "Sector"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sector> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://purl.org/dc/terms/description> "ensure and enforce security e.g. of data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://www.w3.org/2000/01/rdf-schema#label> "Security"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Security> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://purl.org/dc/terms/description> "sell data or information to third parties"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://www.w3.org/2000/01/rdf-schema#label> "Sell Data to Third Parties"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CommercialInterest> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellDataToThirdParties> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://purl.org/dc/terms/description> "sell or commercially provide insights obtained from analysis of data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://www.w3.org/2000/01/rdf-schema#label> "Sell Insights from Data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CommercialInterest> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellInsightsFromData> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://purl.org/dc/terms/description> "sell products or services"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://www.w3.org/2000/01/rdf-schema#label> "Sell Products to Data Subject"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CommercialInterest> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellProductsToDataSubject> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://purl.org/dc/terms/description> "sell or provide targetted advertisements"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://www.w3.org/2000/01/rdf-schema#label> "Sell Targetted Advertisements"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#CommercialInterest> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SellTargettedAdvertisements> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://purl.org/dc/terms/created> "2019-11-26"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://purl.org/dc/terms/creator> "Rudy Jacob" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://purl.org/dc/terms/description> "Information about the consumption of a service, e.g. time and duration of consumption."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://www.w3.org/2000/01/rdf-schema#label> "Service Consumption Behavior"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Behavioral> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://purl.org/dc/terms/description> "optimise service or activity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://www.w3.org/2000/01/rdf-schema#label> "Service Optimization"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceOptimization> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://purl.org/dc/terms/description> "personalise service or activity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://www.w3.org/2000/01/rdf-schema#label> "Service Personalization"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServicePersonalization> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://purl.org/dc/terms/description> "provide service or activity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://www.w3.org/2000/01/rdf-schema#label> "Service Provision"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ServiceProvision> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://purl.org/dc/terms/description> "Information about sexuality and sexual history"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/2000/01/rdf-schema#label> "Sexual"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#External> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualHistory> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualHistory> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualHistory> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualHistory> <http://purl.org/dc/terms/description> "Information about sexual history"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualHistory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualHistory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualHistory> <http://www.w3.org/2000/01/rdf-schema#label> "Sexual History"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualHistory> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualHistory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualPreference> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualPreference> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualPreference> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualPreference> <http://purl.org/dc/terms/description> "Information about sexual preferences"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualPreference> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualPreference> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualPreference> <http://www.w3.org/2000/01/rdf-schema#label> "Sexual Preference"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualPreference> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Sexual> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SexualPreference> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Share> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Share> <http://purl.org/dc/terms/description> "to give data (or a portion of it) to others"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Share> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Share> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Share> <http://www.w3.org/2000/01/rdf-schema#label> "Share"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Share> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Share> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sibling> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sibling> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sibling> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sibling> <http://purl.org/dc/terms/description> "Information about sibling(s)."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sibling> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sibling> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sibling> <http://www.w3.org/2000/01/rdf-schema#label> "Sibling"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sibling> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#FamilyStructure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Sibling> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SingleSignOn> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SingleSignOn> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SingleSignOn> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SingleSignOn> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SingleSignOn> <http://purl.org/dc/terms/description> "Use of credentials or processes that enable using one set of credentials to authenticate multiple contexts."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SingleSignOn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SingleSignOn> <http://www.w3.org/2000/01/rdf-schema#label> "Single Sign On"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SingleSignOn> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#AuthenticationProtocols> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SingleSignOn> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SkinTone> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SkinTone> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SkinTone> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SkinTone> <http://purl.org/dc/terms/description> "Information about skin tone"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SkinTone> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SkinTone> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SkinTone> <http://www.w3.org/2000/01/rdf-schema#label> "Skin Tone"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SkinTone> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SkinTone> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Social> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Social> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Social> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Social> <http://purl.org/dc/terms/description> "Information about social aspects such as family, public life, or professional networks."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Social> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Social> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Social> <http://www.w3.org/2000/01/rdf-schema#label> "Social"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Social> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Social> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://purl.org/dc/terms/description> "Information about social media communication, including the communication itself and metadata."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://www.w3.org/2000/01/rdf-schema#label> "Social Media Communication"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#Social> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Communication> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaCommunication> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaMarketing> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaMarketing> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaMarketing> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaMarketing> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaMarketing> <http://purl.org/dc/terms/description> "market through and on social media."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaMarketing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaMarketing> <http://www.w3.org/2000/01/rdf-schema#label> "Social Media"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaMarketing> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Marketing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialMediaMarketing> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialNetwork> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialNetwork> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialNetwork> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialNetwork> <http://purl.org/dc/terms/description> "Information about friends or connections expressed as a social network"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/2000/01/rdf-schema#label> "Social Network"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Social> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialNetwork> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialStatus> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialStatus> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialStatus> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialStatus> <http://purl.org/dc/terms/description> "Information about social status"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialStatus> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialStatus> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialStatus> <http://www.w3.org/2000/01/rdf-schema#label> "Social Status"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialStatus> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PublicLife> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SocialStatus> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://purl.org/dc/terms/description> "Personal data belonging to one of 'special categories' that are more sensitive and require additional measures"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/2000/01/rdf-schema#comment> "trade union membership, which is explicitly included in the taxative listing in GDPR Art. 9 (1), is not covered yet."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_9/par_1/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/2000/01/rdf-schema#label> "Special Category Personal Data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SpecialCategoryPersonalData> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://purl.org/dc/terms/description> "Practices and policies regarding training of staff members"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://www.w3.org/2000/01/rdf-schema#label> "Staff Training"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#RiskManagementProcedure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StaffTraining> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://purl.org/dc/terms/description> "Deletion or Erasure of data including any deletion guarantees"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://www.w3.org/2000/01/rdf-schema#label> "Storage Deletion"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#StorageRestriction> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDeletion> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://purl.org/dc/terms/description> "Duration or temporal entity denoting limitation on storage of personal data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://www.w3.org/2000/01/rdf-schema#label> "Storage Duration"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#StorageRestriction> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageDuration> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://purl.org/dc/terms/description> "Location or goespatial scope where the data is stored"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://www.w3.org/2000/01/rdf-schema#label> "Storage Location"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#StorageRestriction> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageLocation> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://purl.org/dc/terms/description> "Regularity and temporal span of data restoration/backup mechanisms that guarantee that data is preserved"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://www.w3.org/2000/01/rdf-schema#label> "Storage Restoration"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#StorageRestriction> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestoration> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://purl.org/dc/terms/description> "Restrictions required or followed regarding storage of data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://www.w3.org/2000/01/rdf-schema#label> "Storage Restriction"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#TechnicalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#StorageRestriction> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Store> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Store> <http://purl.org/dc/terms/description> "to keep data for future use"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Store> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Store> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Store> <http://www.w3.org/2000/01/rdf-schema#label> "Store"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Store> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Store> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Structure> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Structure> <http://purl.org/dc/terms/description> "to arrange data according to a structure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Structure> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Structure> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Structure> <http://www.w3.org/2000/01/rdf-schema#label> "Structure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Structure> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Organise> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Structure> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SystematicMonitoring> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SystematicMonitoring> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SystematicMonitoring> <http://purl.org/dc/terms/creator> "Piero Bonatti" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SystematicMonitoring> <http://purl.org/dc/terms/description> "Processing that involves systematic monitoring of individuals"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SystematicMonitoring> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SystematicMonitoring> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SystematicMonitoring> <http://www.w3.org/2000/01/rdf-schema#label> "Systematic Monitoring"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#SystematicMonitoring> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TVViewingBehavior> <http://purl.org/dc/terms/created> "2019-11-26"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TVViewingBehavior> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TVViewingBehavior> <http://purl.org/dc/terms/creator> "Rudy Jacob" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TVViewingBehavior> <http://purl.org/dc/terms/description> "Information about TV viewing behavior, such as timestamps of channel change, duration of viewership, content consumed"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TVViewingBehavior> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TVViewingBehavior> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TVViewingBehavior> <http://www.w3.org/2000/01/rdf-schema#label> "TV Viewing Behavior"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TVViewingBehavior> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServiceConsumptionBehavior> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TVViewingBehavior> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tattoo> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tattoo> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tattoo> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tattoo> <http://purl.org/dc/terms/description> "Information about tattoos"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tattoo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tattoo> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tattoo> <http://www.w3.org/2000/01/rdf-schema#label> "Tattoo"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tattoo> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tattoo> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tax> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tax> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tax> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tax> <http://purl.org/dc/terms/description> "Information about financial tax e.g. tax records or tax due"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tax> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tax> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tax> <http://www.w3.org/2000/01/rdf-schema#label> "Tax"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tax> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tax> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://purl.org/dc/terms/description> "Technical measures required/followed when processing data of the declared category"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://www.w3.org/2000/01/rdf-schema#label> "Technical Measure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalMeasure> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://purl.org/dc/terms/description> "The Technical and Organisational measures used."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://www.w3.org/2000/01/rdf-schema#label> "Technical and Organisational Measure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TechnicalOrganisationalMeasure> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TelephoneNumber> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TelephoneNumber> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TelephoneNumber> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TelephoneNumber> <http://purl.org/dc/terms/description> "Information about telephone number."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TelephoneNumber> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TelephoneNumber> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TelephoneNumber> <http://www.w3.org/2000/01/rdf-schema#label> "Telephone Number"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TelephoneNumber> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Contact> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#TelephoneNumber> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ThirdParty> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ThirdParty> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ThirdParty> <http://purl.org/dc/terms/description> "A ‘third party’ means a natural or legal person, public authority, agency or body other than the data subject, controller, processor and persons who, under the direct authority of the controller or processor, are authorised to process personal data;"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ThirdParty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ThirdParty> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_10/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ThirdParty> <http://www.w3.org/2000/01/rdf-schema#label> "Third Party"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ThirdParty> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Recipient> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#ThirdParty> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Thought> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Thought> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Thought> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Thought> <http://purl.org/dc/terms/description> "Information about thoughts"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Thought> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Thought> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Thought> <http://www.w3.org/2000/01/rdf-schema#label> "Thought"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Thought> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#KnowledgeBelief> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Thought> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tracking> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tracking> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tracking> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tracking> <http://purl.org/dc/terms/description> "Information used to track an individual or group e.g. location or email"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tracking> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tracking> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tracking> <http://www.w3.org/2000/01/rdf-schema#label> "Tracking"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tracking> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PersonalDataCategory> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Tracking> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transaction> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transaction> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transaction> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transaction> <http://purl.org/dc/terms/description> "Information about financial transactions e.g. bank transfers"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transaction> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transaction> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transaction> <http://www.w3.org/2000/01/rdf-schema#label> "Transaction"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transaction> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transaction> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transactional> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transactional> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transactional> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transactional> <http://purl.org/dc/terms/description> "Information about an purchasing, spending or income"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/2000/01/rdf-schema#label> "Transactional"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Financial> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transactional> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transfer> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transfer> <http://purl.org/dc/terms/description> "to move data from one place to another"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transfer> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transfer> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/vocabs/processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transfer> <http://www.w3.org/2000/01/rdf-schema#label> "Transfer"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transfer> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/processing#Transfer> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transfer> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transfer> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transform> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transform> <http://purl.org/dc/terms/description> "to change the form or nature of data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/2000/01/rdf-schema#label> "Transform"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transform> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transmit> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transmit> <http://purl.org/dc/terms/description> "to send out data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transmit> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transmit> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transmit> <http://www.w3.org/2000/01/rdf-schema#label> "Transmit"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transmit> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Disclose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Transmit> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://purl.org/dc/terms/description> "Information about unique identifiers."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://www.w3.org/2000/01/rdf-schema#label> "UID"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.specialprivacy.eu/vocabs/data#UniqueId> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UID> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UsageAnalytics> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UsageAnalytics> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UsageAnalytics> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UsageAnalytics> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UsageAnalytics> <http://purl.org/dc/terms/description> "calculate, analyse, and report user behaviour and events for a service or product."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UsageAnalytics> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UsageAnalytics> <http://www.w3.org/2000/01/rdf-schema#label> "Analytics"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UsageAnalytics> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServiceProvision> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UsageAnalytics> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Use> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Use> <http://purl.org/dc/terms/description> "to use data"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Use> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Use> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://eur-lex.europa.eu/eli/reg/2016/679/art_4/par_2/oj> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Use> <http://www.w3.org/2000/01/rdf-schema#label> "Use"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Use> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Processing> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Use> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://purl.org/dc/terms/creator> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://purl.org/dc/terms/creator> "Javier Fernandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://purl.org/dc/terms/creator> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://purl.org/dc/terms/description> "personalise interfaces presented to the user"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://www.w3.org/2000/01/rdf-schema#label> "User Interface Personalisation"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#ServicePersonalization> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#UserInterfacePersonalisation> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Username> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Username> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Username> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Username> <http://purl.org/dc/terms/description> "Information about usernames."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Username> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Username> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Username> <http://www.w3.org/2000/01/rdf-schema#label> "Username"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Username> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Identifying> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Username> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceCommunicationRecording> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceCommunicationRecording> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceCommunicationRecording> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceCommunicationRecording> <http://purl.org/dc/terms/description> "Information about vocal recorded communication (e.g. telephony, VoIP)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceCommunicationRecording> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceCommunicationRecording> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceCommunicationRecording> <http://www.w3.org/2000/01/rdf-schema#label> "Voice Communication Recording"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceCommunicationRecording> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Communication> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceCommunicationRecording> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceMail> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceMail> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceMail> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceMail> <http://purl.org/dc/terms/description> "Information about voice mail messages."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceMail> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceMail> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceMail> <http://www.w3.org/2000/01/rdf-schema#label> "Voice Mail"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceMail> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Communication> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VoiceMail> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VulnerableDataSubject> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VulnerableDataSubject> <http://purl.org/dc/terms/creator> "Georg Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VulnerableDataSubject> <http://purl.org/dc/terms/creator> "Harshvardhan Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VulnerableDataSubject> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VulnerableDataSubject> <http://purl.org/dc/terms/description> "Data Subjects which should be considered 'vulnerable' and therefore would require additional measures and safeguards"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VulnerableDataSubject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VulnerableDataSubject> <http://www.w3.org/2000/01/rdf-schema#label> "Vulnerable Data Subject"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VulnerableDataSubject> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#DataSubject> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#VulnerableDataSubject> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Weight> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Weight> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Weight> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Weight> <http://purl.org/dc/terms/description> "Information about physical weight"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Weight> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Weight> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Weight> <http://www.w3.org/2000/01/rdf-schema#label> "Weight"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Weight> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#PhysicalCharacteristic> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#Weight> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#WorkHistory> <http://purl.org/dc/terms/created> "2019-06-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#WorkHistory> <http://purl.org/dc/terms/creator> "Elmar Kiesling; Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#WorkHistory> <http://purl.org/dc/terms/creator> "Fajar Ekaputra" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#WorkHistory> <http://purl.org/dc/terms/description> "Information about work history in a professional context"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#WorkHistory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#WorkHistory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://enterprivacy.com/wp-content/uploads/2018/09/Categories-of-Personal-Information.pdf> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#WorkHistory> <http://www.w3.org/2000/01/rdf-schema#label> "Work History"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#WorkHistory> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/dpv#Professional> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#WorkHistory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAddress> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAddress> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAddress> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAddress> <http://purl.org/dc/terms/creator> "Harshvardhan J.Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAddress> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAddress> <http://purl.org/dc/terms/description> "Specifies address of a legal entity such as street address or pin code"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAddress> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAddress> <http://www.w3.org/2000/01/rdf-schema#label> "has address"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAddress> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAlgorithmicLogic> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAlgorithmicLogic> <http://purl.org/dc/terms/creator> "Georg P. Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAlgorithmicLogic> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAlgorithmicLogic> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAlgorithmicLogic> <http://purl.org/dc/terms/description> "Indicates the logic used  in procdessing such as for automated decision making"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAlgorithmicLogic> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAlgorithmicLogic> <http://www.w3.org/2000/01/rdf-schema#label> "has algorithmic logic"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasAlgorithmicLogic> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsentNotice> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsentNotice> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsentNotice> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsentNotice> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsentNotice> <http://purl.org/dc/terms/description> "Specifies the notice provided in context of consent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsentNotice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsentNotice> <http://www.w3.org/2000/01/rdf-schema#comment> "The actual notice that the Data Subject received to consent to, either a text or link to a document, which should be usable to decide whether the form or consent was compliant to legislation, e.g. documenting how the user has been informed about rights and implications (such as, right to data portability,right to recitffy, right to erasure, right to restrict processing, right to object, rights regarding automated decision making or profiling, processors, third parties, sub-processors, outside-EEA transfers, automated decision-making, or other necessary details of the privacy-policy). Can be TextOrDocumentOrURI."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsentNotice> <http://www.w3.org/2000/01/rdf-schema#label> "has consent notice"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsentNotice> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsequences> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsequences> <http://purl.org/dc/terms/creator> "Georg P. Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsequences> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsequences> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsequences> <http://purl.org/dc/terms/description> "Indicates consequences of processing such as for those for Data Subjects in relation to automated decision making"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsequences> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsequences> <http://www.w3.org/2000/01/rdf-schema#label> "has consequences"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasConsequences> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContact> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContact> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContact> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContact> <http://purl.org/dc/terms/creator> "Harshvardhan J.Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContact> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContact> <http://purl.org/dc/terms/description> "Specifies contact details of a legal entity such as phone  or email"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContact> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContact> <http://www.w3.org/2000/01/rdf-schema#label> "has contact"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContact> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContext> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContext> <http://purl.org/dc/terms/description> "Indiciates a purpose is restricted to the specified context(s)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContext> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContext> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/dpv#Purpose> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContext> <http://www.w3.org/2000/01/rdf-schema#label> "has context"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContext> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/dpv#Context> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasContext> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://purl.org/dc/terms/created> "2019-04-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://purl.org/dc/terms/description> "Indicates association with a Data Controller."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://www.w3.org/2000/01/rdf-schema#label> "has data controller"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataController> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSource> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSource> <http://purl.org/dc/terms/creator> "Georg P. Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSource> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSource> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSource> <http://purl.org/dc/terms/description> "Indicates the source or origin of data being processed"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSource> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSource> <http://www.w3.org/2000/01/rdf-schema#label> "has data source"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSource> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://purl.org/dc/terms/created> "2019-04-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://purl.org/dc/terms/description> "Indicates association with a specific Data Subject or a group or category of Data Subjects."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://www.w3.org/2000/01/rdf-schema#label> "has data subject"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDataSubject> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://purl.org/dc/terms/description> "Indicates information about duration"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://www.w3.org/2000/01/rdf-schema#label> "has duration"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasDuration> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiry> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiry> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiry> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiry> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiry> <http://purl.org/dc/terms/description> "Generic property specifying when or under which condition(s) the consent will expire"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiry> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiry> <http://www.w3.org/2000/01/rdf-schema#label> "has expiry"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiry> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://purl.org/dc/terms/description> "Specifies the condition or event that determines the expiry of consent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://www.w3.org/2000/01/rdf-schema#comment> "Can be TextOrDocumentOrURI"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://www.w3.org/2000/01/rdf-schema#label> "has expiry condition"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/dpv#expiry> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryCondition> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://purl.org/dc/terms/description> "Specifies the expiry time or duration for consent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://www.w3.org/2000/01/rdf-schema#label> "has expiry time"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2006/time#TemporalEntity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/dpv#expiry> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasExpiryTime> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasHumanInvolvement> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasHumanInvolvement> <http://purl.org/dc/terms/creator> "Georg P. Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasHumanInvolvement> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasHumanInvolvement> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasHumanInvolvement> <http://purl.org/dc/terms/description> "Indicates Involvement of humans in processing such as within automated decision making process"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasHumanInvolvement> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasHumanInvolvement> <http://www.w3.org/2000/01/rdf-schema#comment> "Human involvement is also relevant to 'human in the loop'"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasHumanInvolvement> <http://www.w3.org/2000/01/rdf-schema#label> "has human involvement"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasHumanInvolvement> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasIdentifier> <http://purl.org/dc/terms/created> "2020-11-25"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasIdentifier> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasIdentifier> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasIdentifier> <http://purl.org/dc/terms/creator> "Harshvardhan J.Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasIdentifier> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasIdentifier> <http://purl.org/dc/terms/description> "Specifies an identifier for the entity such as registeration number or official ID"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasIdentifier> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasIdentifier> <http://www.w3.org/2000/01/rdf-schema#label> "has identifier"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasIdentifier> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLegalBasis> <http://purl.org/dc/terms/created> "2019-04-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLegalBasis> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLegalBasis> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLegalBasis> <http://purl.org/dc/terms/description> "Indicates applicability of a Legal Basis."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLegalBasis> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLegalBasis> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLegalBasis> <http://www.w3.org/2000/01/rdf-schema#label> "has legal basis"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLegalBasis> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://purl.org/dc/terms/description> "Indicates information about location"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://www.w3.org/2000/01/rdf-schema#label> "has location"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasLocation> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasName> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasName> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasName> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasName> <http://purl.org/dc/terms/creator> "Harshvardhan J.Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasName> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasName> <http://purl.org/dc/terms/description> "Specifies name of a legal entity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasName> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasName> <http://www.w3.org/2000/01/rdf-schema#label> "has name"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasName> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://purl.org/dc/terms/created> "2019-04-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://purl.org/dc/terms/description> "Indicates association with a Personal Data Category."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://www.w3.org/2000/01/rdf-schema#label> "has personal data category"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPersonalDataCategory> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://purl.org/dc/terms/created> "2019-04-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://purl.org/dc/terms/description> "Indicates association with a Processing (of personal data) instance or category."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://www.w3.org/2000/01/rdf-schema#label> "has processing"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProcessing> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://purl.org/dc/terms/description> "Specifies the entity that provisioned or provided consent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://www.w3.org/2000/01/rdf-schema#comment> "Normally this would be the dataSubject, but in some exceptional cases, the consent might be given on behalf by someone else, e.g. parents of minors."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://www.w3.org/2000/01/rdf-schema#label> "has provision by"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionBy> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionByJustification> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionByJustification> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionByJustification> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionByJustification> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionByJustification> <http://purl.org/dc/terms/description> "Specifies the justification for entity providing consent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionByJustification> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionByJustification> <http://www.w3.org/2000/01/rdf-schema#comment> "This field can be used to proivde a justification why the provision was provided by another DataSubject or legal entity,  e.g. declariing the relationship (parent, guardian), in combination with the field provisionBy"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionByJustification> <http://www.w3.org/2000/01/rdf-schema#label> "has provision by justification"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionByJustification> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionMethod> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionMethod> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionMethod> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionMethod> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionMethod> <http://purl.org/dc/terms/description> "Specifies the method by which consent was provisioned or provided"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionMethod> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionMethod> <http://www.w3.org/2000/01/rdf-schema#comment> "Can be used to record information of how consent was provided e.g. by a click to a form, in writing, etc., by logging into a system and confirm per email, or with some additional authentication, etc."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionMethod> <http://www.w3.org/2000/01/rdf-schema#label> "has provision method"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionMethod> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionTime> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionTime> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionTime> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionTime> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionTime> <http://purl.org/dc/terms/description> "Specifies the instant in time when consent was given"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionTime> <http://www.w3.org/2000/01/rdf-schema#label> "has provision time"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionTime> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2006/time#Instant> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasProvisionTime> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://purl.org/dc/terms/created> "2019-04-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://purl.org/dc/terms/description> "Indicates assocation with a Purpose (of processing personal data)."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://www.w3.org/2000/01/rdf-schema#label> "has purpose"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasPurpose> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://purl.org/dc/terms/created> "2019-04-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://purl.org/dc/terms/description> "Indicates a recipient of personal data."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://www.w3.org/2000/01/rdf-schema#label> "has recipient"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRecipient> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRepresentative> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRepresentative> <http://purl.org/dc/terms/creator> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRepresentative> <http://purl.org/dc/terms/creator> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRepresentative> <http://purl.org/dc/terms/creator> "Harshvardhan J.Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRepresentative> <http://purl.org/dc/terms/creator> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRepresentative> <http://purl.org/dc/terms/description> "Specifies representative of the legal entity"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRepresentative> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRepresentative> <http://www.w3.org/2000/01/rdf-schema#label> "has representative"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRepresentative> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRight> <http://purl.org/dc/terms/created> "2020-11-18"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRight> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRight> <http://purl.org/dc/terms/description> "Indicates applicability of a Right."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRight> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRight> <http://www.w3.org/2000/01/rdf-schema#label> "has right"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRight> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRisk> <http://purl.org/dc/terms/created> "2020-11-18"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRisk> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRisk> <http://purl.org/dc/terms/description> "Indicates applicability of a Risk."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRisk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRisk> <http://www.w3.org/2000/01/rdf-schema#label> "has risk"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasRisk> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasSector> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasSector> <http://purl.org/dc/terms/description> "Indicates the purpose is associated with activities in the indicated (Economic) Sector(s)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasSector> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasSector> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/dpv#Context> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasSector> <http://www.w3.org/2000/01/rdf-schema#label> "has sector"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasSector> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/dpv#Sector> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasSector> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://purl.org/dc/terms/creator> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://purl.org/dc/terms/description> "Indicates information about storage"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.specialprivacy.eu/> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://www.w3.org/2000/01/rdf-schema#label> "has storage"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasStorage> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://purl.org/dc/terms/created> "2019-04-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://purl.org/dc/terms/creator> "Javier Ferenandez" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://purl.org/dc/terms/description> "Indicates use of a Technical or Organisational measure."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://purl.org/dc/terms/modified> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://www.w3.org/2000/01/rdf-schema#label> "has technical and organisational measure"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasTechnicalOrganisationalMeasure> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://purl.org/dc/terms/description> "Specifies the entity that withdrew consent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://www.w3.org/2000/01/rdf-schema#comment> "Normally this would be the dataSubject, but in some exceptional cases, the consent might be withdraawn on behalf by someone else, e.g. parents of minors."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://www.w3.org/2000/01/rdf-schema#label> "has withdrawal by"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/dpv#LegalEntity> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalBy> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalByJustification> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalByJustification> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalByJustification> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalByJustification> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalByJustification> <http://purl.org/dc/terms/description> "Specifies the justification for entity withdrawing consent"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalByJustification> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalByJustification> <http://www.w3.org/2000/01/rdf-schema#comment> "This field can be used to proivde a justification why the weithdrawal was done by another DataSubject or legal entity, e.g. declariing the relationship (parent, guardian), in combination with the field withdrawalBy"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalByJustification> <http://www.w3.org/2000/01/rdf-schema#label> "has withdrawal by justification"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalByJustification> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalMethod> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalMethod> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalMethod> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalMethod> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalMethod> <http://purl.org/dc/terms/description> "Specifries the method by which consent can be/has been withdrawn"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalMethod> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalMethod> <http://www.w3.org/2000/01/rdf-schema#comment> "Can be used to record information of how to withdraw consent, e.g. by a click to a form, in writing, etc., by logging into a system and confirm per email, or with some additional authentication, etc."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalMethod> <http://www.w3.org/2000/01/rdf-schema#label> "has withdrawal method"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalMethod> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalTime> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalTime> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalTime> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalTime> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalTime> <http://purl.org/dc/terms/description> "Specifies the instant in time when consent was withdrawn"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalTime> <http://www.w3.org/2000/01/rdf-schema#label> "has withdrawal time"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalTime> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2006/time#Instant> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#hasWithdrawalTime> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://purl.org/dc/terms/created> "2019-04-05"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://purl.org/dc/terms/creator> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://purl.org/dc/terms/creator> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://purl.org/dc/terms/description> "Specifies consent is 'explicit'"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://www.w3.org/2000/01/rdf-schema#comment> "The conditions for what is considered 'explicit consent' differ by norms and laws."@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://www.w3.org/2000/01/rdf-schema#label> "is explicit"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#boolean> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#isExplicit> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#measureImplementedBy> <http://purl.org/dc/terms/created> "2019-05-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#measureImplementedBy> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#measureImplementedBy> <http://purl.org/dc/terms/description> "a generic Property to describe how the measure is implemented"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#measureImplementedBy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#measureImplementedBy> <http://www.w3.org/2000/01/rdf-schema#label> "measure implemented by"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#measureImplementedBy> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#mitigatesRisk> <http://purl.org/dc/terms/created> "2020-11-04"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#mitigatesRisk> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#mitigatesRisk> <http://purl.org/dc/terms/description> "Indicates mitigation of risk(s)"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#mitigatesRisk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#mitigatesRisk> <http://www.w3.org/2000/01/rdf-schema#label> "mitigates risk"@en <http://www.w3.org/ns/dpv#> .
+<http://www.w3.org/ns/dpv#mitigatesRisk> <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "accepted"@en <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/abstract> "The Data Privacy Vocabulary (DPV) provides terms (classes and properties) to represent information about legally compliant personal data handling, which includes purposes, processing, personal data, technical and organisational measures."@en <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Beatriz Esteves" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Bert Bos" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Bud Bruegger" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Elmar Kiesling" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Eva Schlehahn" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Fajar J. Ekaputra" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Georg P Krog" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Javier D. Fernández" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Mark Lizar" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Paul Ryan" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Piero Bonatti" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Ramisa Gachpaz Hamed" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Rigo Wenning" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Rob Brennan" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/contributor> "Simon Steyskal" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/created> "2019-06-18"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/creator> "Axel Polleres" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/creator> "Harshvardhan J. Pandit" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/description> "The Data Privacy Vocabulary (DPV) provides terms (classes and properties) to represent information about legally compliant personal data handling, which includes purposes, processing, personal data, technical and organisational measures."@en <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/modified> "2021-01-14"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/source> <https://www.w3.org/community/dpvcg/> <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/dc/terms/title> "Data Privacy Vocabulary"@en <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/vocab/vann/preferredNamespacePrefix> "dpv" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://purl.org/vocab/vann/preferredNamespaceUri> "https://w3.org/ns/dpv" <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> <http://www.w3.org/ns/dpv#> .
+<https://w3.org/ns/dpv> <http://www.w3.org/2002/07/owl#versionInfo> "0.2" <http://www.w3.org/ns/dpv#> .

--- a/overrides.ts
+++ b/overrides.ts
@@ -25,6 +25,21 @@ export const overrides: Record<string, Override> = {
   cc: { file: 'https://creativecommons.org/schema.rdf' },
   ctag: { skip: true },
   doap: { mediaType: 'application/rdf+xml' },
+  dpv: {
+    files: [{
+      mediaType: 'application/ld+json',
+      file: 'https://dpvcg.github.io/dpv/dpv.jsonld'
+    }, {
+      mediaType: 'application/rdf+xml',
+      file: 'https://dpvcg.github.io/dpv/dpv.rdf'
+    }, {
+      mediaType: 'text/n3',
+      file: 'https://dpvcg.github.io/dpv/dpv.n3'
+    }, {
+      mediaType: 'text/turtle',
+      file: 'https://dpvcg.github.io/dpv/dpv.ttl'
+    }]
+  },
   dtype: { mediaType: 'application/rdf+xml' },
   earl: {
     xmlParserOptions: {

--- a/src/prefixes.ts
+++ b/src/prefixes.ts
@@ -10,6 +10,7 @@ const prefixes = {
   dcat: 'http://www.w3.org/ns/dcat#',
   dcterms: 'http://purl.org/dc/terms/',
   doap: 'http://usefulinc.com/ns/doap#',
+  dpv: 'http://www.w3.org/ns/dpv#',
   dqv: 'http://www.w3.org/ns/dqv#',
   dtype: 'http://www.linkedmodel.org/schema/dtype#',
   duv: 'http://www.w3.org/ns/duv#',


### PR DESCRIPTION
Add `dpv:`  prefix and vocabulary for Data Privacy Vocabulary (DPV).

The namespace for DPV terms is [`http://www.w3.org/ns/dpv#`](http://www.w3.org/ns/dpv#)  
The suggested prefix for the DPV namespace is `dpv`  
The DPV and its documentation is available on [GitHub](https://github.com/dpvcg/dpv).

The Data Privacy Vocabulary (DPV) provides terms (classes and properties) to describe and represent information related to processing of personal data based on established requirements such as for the EU General Data Protection Regulation (GDPR). 
