### PR TITLE
feat: Add Shape Expression Vocabulary (ShEx)

### DIFF
--- a/ontologies/_index.nq
+++ b/ontologies/_index.nq
@@ -335,6 +335,11 @@
 <https://prefix.zazuko.com/sh:> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shacl#> .
 <https://prefix.zazuko.com/sh:> <http://www.w3.org/ns/rdfa#prefix> "sh" .
 <https://prefix.zazuko.com/sh:> <http://www.w3.org/ns/rdfa#uri> <http://www.w3.org/ns/shacl#> .
+<https://prefix.zazuko.com/shex:> <http://dbpedia.org/ontology/filename> "ontologies/shex.nq" .
+<https://prefix.zazuko.com/shex:> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/rdfa#PrefixMapping> .
+<https://prefix.zazuko.com/shex:> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> .
+<https://prefix.zazuko.com/shex:> <http://www.w3.org/ns/rdfa#prefix> "shex" .
+<https://prefix.zazuko.com/shex:> <http://www.w3.org/ns/rdfa#uri> <http://www.w3.org/ns/shex#> .
 <https://prefix.zazuko.com/sioc:> <http://dbpedia.org/ontology/filename> "ontologies/sioc.nq" .
 <https://prefix.zazuko.com/sioc:> <http://purl.org/dc/terms/description> "SIOC (Semantically-Interlinked Online Communities) is an ontology for describing the information in online communities. \r\nThis information can be used to export information from online communities and to link them together. The scope of the application areas that SIOC can be used for includes (and is not limited to) weblogs, message boards, mailing lists and chat channels." .
 <https://prefix.zazuko.com/sioc:> <http://purl.org/dc/terms/title> "SIOC Core Ontology Namespace" .

--- a/ontologies/shex.nq
+++ b/ontologies/shex.nq
@@ -1,0 +1,474 @@
+<http://www.w3.org/ns/shex#> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://shex.io/shex-semantics> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#> <http://www.w3.org/2002/07/owl#versionInfo> <https://github.com/shexSpec/shexspec.github.io/commit/e05f8e97471f5271f50612bed253102f770364b4> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#> <https://www.w3.org/ns/http;//purl.org/dc/terms/date> "2017-07-07"^^<http://www.w3.org/2001/XMLSchema#date> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#> <https://www.w3.org/ns/http;//purl.org/dc/terms/description> "This document describes the RDFS vocabulary description used in the Shape Expression Language (ShEx) [[shex-semantics]] along with the default JSON-LD Context and shape expression to validate RDF versions of shapes."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#> <https://www.w3.org/ns/http;//purl.org/dc/terms/title> "Shape Expression Vocabulary"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Annotation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Annotation> <http://www.w3.org/2000/01/rdf-schema#comment> "Annotations provide a format-independent way to provide additional information about elements in a schema. "@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Annotation> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Annotation> <http://www.w3.org/2000/01/rdf-schema#label> "Annotation"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/2000/01/rdf-schema#comment> "A TripleExpression composed of one or more sub-expressions, all of which must match."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/2000/01/rdf-schema#label> "Each Of"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#TripleExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStem> <http://www.w3.org/2000/01/rdf-schema#comment> "An IRI prefix used for matching IRIs."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStem> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStem> <http://www.w3.org/2000/01/rdf-schema#label> "IRI Stem"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStem> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#Stem> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStemRange> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStemRange> <http://www.w3.org/2000/01/rdf-schema#comment> "An IRI prefix (or wildcard) along with a set of excluded values, used for node matching."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStemRange> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStemRange> <http://www.w3.org/2000/01/rdf-schema#label> "IRI StemRange"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#IriStemRange> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Language> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Language> <http://www.w3.org/2000/01/rdf-schema#comment> "An Language tag used for matching Literal Languages."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Language> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Language> <http://www.w3.org/2000/01/rdf-schema#label> "Language"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStem> <http://www.w3.org/2000/01/rdf-schema#comment> "An Language prefix used for matching Literal Languages."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStem> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStem> <http://www.w3.org/2000/01/rdf-schema#label> "Language Stem"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStem> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#Stem> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStemRange> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStemRange> <http://www.w3.org/2000/01/rdf-schema#comment> "An Language prefix (or wildcard) along with a set of excluded values, used for node matching."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStemRange> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStemRange> <http://www.w3.org/2000/01/rdf-schema#label> "Language StemRange"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LanguageStemRange> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStem> <http://www.w3.org/2000/01/rdf-schema#comment> "An Literal prefix used for matching Literals."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStem> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStem> <http://www.w3.org/2000/01/rdf-schema#label> "Literal Stem"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStem> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#Stem> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStemRange> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStemRange> <http://www.w3.org/2000/01/rdf-schema#comment> "An Literal prefix (or wildcard) along with a set of excluded values, used for node matching."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStemRange> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStemRange> <http://www.w3.org/2000/01/rdf-schema#label> "Literal StemRange"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#LiteralStemRange> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/2000/01/rdf-schema#comment> "A constraint on the type or value of an RDF Node."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/2000/01/rdf-schema#label> "Node Constraint"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#NodeKind> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#NodeKind> <http://www.w3.org/2000/01/rdf-schema#comment> "The set of kinds of RDF Nodes."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#NodeKind> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#NodeKind> <http://www.w3.org/2000/01/rdf-schema#label> "Node Kind"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/2000/01/rdf-schema#comment> "A TripleExpression composed of one or more sub-expressions, one of which must match."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/2000/01/rdf-schema#label> "One Of"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#TripleExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Schema> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Schema> <http://www.w3.org/2000/01/rdf-schema#comment> "A Schema contains the set of shapes, used for matching a focus node."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Schema> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Schema> <http://www.w3.org/2000/01/rdf-schema#label> "Schema"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#SemAct> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#SemAct> <http://www.w3.org/2000/01/rdf-schema#comment> "A list of Semantic Actions that serve as an extension point for Shape Expressions. They appear in lists in Schema's startActs and Shape, OneOf, EachOf and TripleConstraint's semActs."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#SemAct> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#SemAct> <http://www.w3.org/2000/01/rdf-schema#label> "Semantic Actions"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Shape> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Shape> <http://www.w3.org/2000/01/rdf-schema#comment> "A shapes schema is captured in a Schema object where shapes is a mapping from shape label to shape expression."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Shape> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Shape> <http://www.w3.org/2000/01/rdf-schema#label> "Shape Or"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Shape> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeAnd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeAnd> <http://www.w3.org/2000/01/rdf-schema#comment> "A ShapeExpression composed of one or more sub-expressions, all of which must match."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeAnd> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeAnd> <http://www.w3.org/2000/01/rdf-schema#label> "Shape And"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeAnd> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/2000/01/rdf-schema#comment> "The abstract class of Shape Expressions."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/2000/01/rdf-schema#label> "Shape Expression"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeExternal> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeExternal> <http://www.w3.org/2000/01/rdf-schema#comment> "A reference to a shape defined in some external Schema."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeExternal> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeExternal> <http://www.w3.org/2000/01/rdf-schema#label> "Shape External"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeExternal> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeNot> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeNot> <http://www.w3.org/2000/01/rdf-schema#comment> "A ShapeNot is satisfied when it’s included ShapeExpression is not satisfied."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeNot> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeNot> <http://www.w3.org/2000/01/rdf-schema#label> "Shape Not"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeNot> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeOr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeOr> <http://www.w3.org/2000/01/rdf-schema#comment> "A ShapeExpression composed of one or more sub-expressions, one of which must match."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeOr> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeOr> <http://www.w3.org/2000/01/rdf-schema#label> "Shape Or"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#ShapeOr> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Stem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Stem> <http://www.w3.org/2000/01/rdf-schema#comment> "Abstract class for Stems"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Stem> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Stem> <http://www.w3.org/2000/01/rdf-schema#label> "Stem"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/2000/01/rdf-schema#comment> "Abstract Class for Stem Ranges"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/2000/01/rdf-schema#label> "StemRange"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/2000/01/rdf-schema#comment> "A constraint on a triple having a specific predicate and optionally a shape expression used for matching values."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/2000/01/rdf-schema#label> "Triple Constraint"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/shex#TripleExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#TripleExpression> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#TripleExpression> <http://www.w3.org/2000/01/rdf-schema#comment> "The abstract class of Triple Expressions."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#TripleExpression> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#TripleExpression> <http://www.w3.org/2000/01/rdf-schema#label> "Triple Expression"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Wildcard> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Wildcard> <http://www.w3.org/2000/01/rdf-schema#comment> "Indicates that a stem is a Wildcard, rather than a URI prefix."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Wildcard> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#Wildcard> <http://www.w3.org/2000/01/rdf-schema#label> "Wildcard"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#annotation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#annotation> <http://www.w3.org/2000/01/rdf-schema#comment> "Annotations on a TripleExpression."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#annotation> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n20 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#annotation> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#annotation> <http://www.w3.org/2000/01/rdf-schema#label> "annotation"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#annotation> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#Annotation> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#bnode> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/shex#NodeKind> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#bnode> <http://www.w3.org/2000/01/rdf-schema#comment> "Requires node to be a Blank Node"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#bnode> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#bnode> <http://www.w3.org/2000/01/rdf-schema#label> "bnode"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#closed> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#closed> <http://www.w3.org/2000/01/rdf-schema#comment> "Indicates that a Shape is closed, meaning that it may contain no property values other than those used within TripleConstraints."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#closed> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#Shape> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#closed> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#closed> <http://www.w3.org/2000/01/rdf-schema#label> "closed"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#closed> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#boolean> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#code> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#code> <http://www.w3.org/2000/01/rdf-schema#comment> "Code executed by Semantic Action."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#code> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#SemAct> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#code> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#code> <http://www.w3.org/2000/01/rdf-schema#label> "code"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#code> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#datatype> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#datatype> <http://www.w3.org/2000/01/rdf-schema#comment> "A datatype constraint."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#datatype> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#datatype> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#datatype> <http://www.w3.org/2000/01/rdf-schema#label> "datatype"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#datatype> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#exclusion> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#exclusion> <http://www.w3.org/2000/01/rdf-schema#comment> "Values that are excluded from value matching."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#exclusion> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#exclusion> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#exclusion> <http://www.w3.org/2000/01/rdf-schema#label> "exclusion"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#exclusion> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n19 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expression> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expression> <http://www.w3.org/2000/01/rdf-schema#comment> "Expression associated with the TripleExpression."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expression> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#Shape> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expression> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expression> <http://www.w3.org/2000/01/rdf-schema#label> "expression"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expression> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#TripleExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expressions> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expressions> <http://www.w3.org/2000/01/rdf-schema#comment> "List of 2 or more expressions associated with the TripleExpression."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expressions> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n5 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expressions> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expressions> <http://www.w3.org/2000/01/rdf-schema#label> "expressions"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#expressions> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#TripleExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#extra> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#extra> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties which may have extra values beyond those matched through a constraint."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#extra> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#Shape> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#extra> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#extra> <http://www.w3.org/2000/01/rdf-schema#label> "extra"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#extra> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Resource> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#flags> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#flags> <http://www.w3.org/2000/01/rdf-schema#comment> "Regular expression flags"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#flags> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#flags> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#flags> <http://www.w3.org/2000/01/rdf-schema#label> "flags"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#flags> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#fractiondigits> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#fractiondigits> <http://www.w3.org/2000/01/rdf-schema#comment> "for \"fractiondigits\" constraints, v is less than or equals the number of digits to the right of the decimal place in the XML Schema canonical form[xmlschema-2] of the value of n, ignoring trailing zeros."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#fractiondigits> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#fractiondigits> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#fractiondigits> <http://www.w3.org/2000/01/rdf-schema#label> "fraction digits"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#fractiondigits> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#fractiondigits> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#inverse> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#inverse> <http://www.w3.org/2000/01/rdf-schema#comment> "Constrains the subject of a triple, rather than the object."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#inverse> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#inverse> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#inverse> <http://www.w3.org/2000/01/rdf-schema#label> "inverse"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#inverse> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#boolean> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#iri> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/shex#NodeKind> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#iri> <http://www.w3.org/2000/01/rdf-schema#comment> "Requires node to be an IRI"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#iri> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#iri> <http://www.w3.org/2000/01/rdf-schema#label> "iri"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#languageTag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#languageTag> <http://www.w3.org/2000/01/rdf-schema#comment> "The value used to match the language tag of a language-tagged string."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#languageTag> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#Language> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#languageTag> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#languageTag> <http://www.w3.org/2000/01/rdf-schema#label> "language tag"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#languageTag> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#length> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#length> <http://www.w3.org/2000/01/rdf-schema#comment> "The exact length of the value of the cell."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#length> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#length> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#length> <http://www.w3.org/2000/01/rdf-schema#label> "length"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#length> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#length> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#stringFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#literal> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/shex#NodeKind> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#literal> <http://www.w3.org/2000/01/rdf-schema#comment> "Requires node to be an rdf:Literal"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#literal> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#literal> <http://www.w3.org/2000/01/rdf-schema#label> "literal"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#max> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#max> <http://www.w3.org/2000/01/rdf-schema#comment> "Maximum number of times this TripleExpression may match; -1 for “*”"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#max> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n2 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#max> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#max> <http://www.w3.org/2000/01/rdf-schema#label> "maximum cardinality"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#max> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxexclusive> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxexclusive> <http://www.w3.org/2000/01/rdf-schema#comment> "An atomic property that contains a single number that is the maximum valid value (exclusive)."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxexclusive> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxexclusive> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxexclusive> <http://www.w3.org/2000/01/rdf-schema#label> "max exclusive"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxexclusive> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n17 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxexclusive> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxinclusive> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxinclusive> <http://www.w3.org/2000/01/rdf-schema#comment> "An atomic property that contains a single number that is the maximum valid value (inclusive)."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxinclusive> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxinclusive> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxinclusive> <http://www.w3.org/2000/01/rdf-schema#label> "max inclusive"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxinclusive> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n0 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxinclusive> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxlength> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxlength> <http://www.w3.org/2000/01/rdf-schema#comment> "A numeric atomic property that contains a single integer that is the maximum length of the value."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxlength> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxlength> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxlength> <http://www.w3.org/2000/01/rdf-schema#label> "max length"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxlength> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#maxlength> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#stringFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#min> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#min> <http://www.w3.org/2000/01/rdf-schema#comment> "Minimum number of times this TripleExpression may match."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#min> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n13 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#min> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#min> <http://www.w3.org/2000/01/rdf-schema#label> "minimum cardinatliy"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#min> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minexclusive> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minexclusive> <http://www.w3.org/2000/01/rdf-schema#comment> "An atomic property that contains a single number that is the minimum valid value (exclusive)."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minexclusive> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minexclusive> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minexclusive> <http://www.w3.org/2000/01/rdf-schema#label> "min exclusive"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minexclusive> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n6 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minexclusive> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#mininclusive> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#mininclusive> <http://www.w3.org/2000/01/rdf-schema#comment> "An atomic property that contains a single number that is the minimum valid value (inclusive)."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#mininclusive> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#mininclusive> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#mininclusive> <http://www.w3.org/2000/01/rdf-schema#label> "min inclusive"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#mininclusive> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n1 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#mininclusive> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minlength> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minlength> <http://www.w3.org/2000/01/rdf-schema#comment> "An atomic property that contains a single integer that is the minimum length of the value."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minlength> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minlength> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minlength> <http://www.w3.org/2000/01/rdf-schema#label> "min length"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minlength> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#minlength> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#stringFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#name> <http://www.w3.org/2000/01/rdf-schema#comment> "Identifier of SemAct extension."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#name> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#SemAct> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#name> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#name> <http://www.w3.org/2000/01/rdf-schema#label> "name"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#name> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Resource> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nodeKind> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nodeKind> <http://www.w3.org/2000/01/rdf-schema#comment> "Restiction on the kind of node matched; restricted to the defined instances of NodeKind. One of shex:iri, shex:bnode, shex:literal, or shex:nonliteral."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nodeKind> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nodeKind> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nodeKind> <http://www.w3.org/2000/01/rdf-schema#label> "node kind"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nodeKind> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#NodeKind> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nonliteral> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/shex#NodeKind> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nonliteral> <http://www.w3.org/2000/01/rdf-schema#comment> "Requires node to be a Blank Node or IRI"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nonliteral> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#nonliteral> <http://www.w3.org/2000/01/rdf-schema#label> "nonliteral"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/2000/01/rdf-schema#comment> "Abstract property of numeric facets on a NodeConstraint."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/2000/01/rdf-schema#label> ""@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#xsFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#object> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#object> <http://www.w3.org/2000/01/rdf-schema#comment> "The object of an Annotation."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#object> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#Annotation> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#object> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#object> <http://www.w3.org/2000/01/rdf-schema#label> "object"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#object> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Resource> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#pattern> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#pattern> <http://www.w3.org/2000/01/rdf-schema#comment> "A regular expression used for matching a value."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#pattern> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#pattern> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#pattern> <http://www.w3.org/2000/01/rdf-schema#label> "pattern"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#pattern> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#pattern> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#stringFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#predicate> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#predicate> <http://www.w3.org/2000/01/rdf-schema#comment> "The predicate of a TripleConstraint or Annotation."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#predicate> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n9 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#predicate> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#predicate> <http://www.w3.org/2000/01/rdf-schema#label> "predicate"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#predicate> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Resource> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#semActs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#semActs> <http://www.w3.org/2000/01/rdf-schema#comment> "Semantic Actions on this TripleExpression."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#semActs> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n7 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#semActs> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#semActs> <http://www.w3.org/2000/01/rdf-schema#label> "semantic action"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#semActs> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#SemAct> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExpr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExpr> <http://www.w3.org/2000/01/rdf-schema#comment> "Shape Expression referenced by this shape."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExpr> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#ShapeNot> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExpr> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExpr> <http://www.w3.org/2000/01/rdf-schema#label> "shape expression"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExpr> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExprs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExprs> <http://www.w3.org/2000/01/rdf-schema#comment> "A list of 2 or more Shape Expressions referenced by this shape."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExprs> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n22 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExprs> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExprs> <http://www.w3.org/2000/01/rdf-schema#label> "shape expressions"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExprs> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapeExprs> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#shapeExpr> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapes> <http://www.w3.org/2000/01/rdf-schema#comment> "Shapes in this Schema."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapes> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#Schema> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapes> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapes> <http://www.w3.org/2000/01/rdf-schema#label> "shapes"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#shapes> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#start> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#start> <http://www.w3.org/2000/01/rdf-schema#comment> "A ShapeExpression matched against the focus node prior to any other mapped expressions."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#start> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#Schema> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#start> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#start> <http://www.w3.org/2000/01/rdf-schema#label> "start"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#start> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#startActs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#startActs> <http://www.w3.org/2000/01/rdf-schema#comment> "Semantic Actions run on the Schema."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#startActs> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#Schema> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#startActs> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#startActs> <http://www.w3.org/2000/01/rdf-schema#label> "start actions"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#startActs> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#SemAct> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stem> <http://www.w3.org/2000/01/rdf-schema#comment> "A stem value used for matching or excluding values."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stem> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n23 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stem> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stem> <http://www.w3.org/2000/01/rdf-schema#label> "stem"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stem> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n3 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stringFacet> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stringFacet> <http://www.w3.org/2000/01/rdf-schema#comment> "An abstract property of string facets on a NodeConstraint."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stringFacet> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stringFacet> <http://www.w3.org/2000/01/rdf-schema#label> ""@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#stringFacet> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#xsFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#totaldigits> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#totaldigits> <http://www.w3.org/2000/01/rdf-schema#comment> "for \"totaldigits\" constraints, v equals the number of digits in the XML Schema canonical form[xmlschema-2] of the value of n"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#totaldigits> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#totaldigits> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#totaldigits> <http://www.w3.org/2000/01/rdf-schema#label> "total digits"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#totaldigits> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#totaldigits> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/shex#numericFacet> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#valueExpr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#valueExpr> <http://www.w3.org/2000/01/rdf-schema#comment> "A ShapeExpression used for matching the object (or subject if inverted) of a TripleConstraint."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#valueExpr> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#valueExpr> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#valueExpr> <http://www.w3.org/2000/01/rdf-schema#label> "value expression"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#valueExpr> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/shex#ShapeExpression> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#values> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#values> <http://www.w3.org/2000/01/rdf-schema#comment> "A value restriction on a NodeConstraint."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#values> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#values> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#values> <http://www.w3.org/2000/01/rdf-schema#label> "values"@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#values> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n15 <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#xsFacet> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#xsFacet> <http://www.w3.org/2000/01/rdf-schema#comment> "An abstract property of string and numeric facets on a NodeConstraint."@en <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#xsFacet> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/shex#NodeConstraint> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#xsFacet> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/shex#> <http://www.w3.org/ns/shex#> .
+<http://www.w3.org/ns/shex#xsFacet> <http://www.w3.org/2000/01/rdf-schema#label> ""@en <http://www.w3.org/ns/shex#> .
+_:c14n0 <http://www.w3.org/2002/07/owl#unionOf> _:c14n48 <http://www.w3.org/ns/shex#> .
+_:c14n1 <http://www.w3.org/2002/07/owl#unionOf> _:c14n42 <http://www.w3.org/ns/shex#> .
+_:c14n10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#Language> <http://www.w3.org/ns/shex#> .
+_:c14n10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n16 <http://www.w3.org/ns/shex#> .
+_:c14n11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/shex#> .
+_:c14n11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n4 <http://www.w3.org/ns/shex#> .
+_:c14n12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/ns/shex#> .
+_:c14n12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n13 <http://www.w3.org/2002/07/owl#unionOf> _:c14n32 <http://www.w3.org/ns/shex#> .
+_:c14n14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#ShapeAnd> <http://www.w3.org/ns/shex#> .
+_:c14n14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n18 <http://www.w3.org/ns/shex#> .
+_:c14n15 <http://www.w3.org/2002/07/owl#unionOf> _:c14n39 <http://www.w3.org/ns/shex#> .
+_:c14n16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#Stem> <http://www.w3.org/ns/shex#> .
+_:c14n16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n40 <http://www.w3.org/ns/shex#> .
+_:c14n17 <http://www.w3.org/2002/07/owl#unionOf> _:c14n45 <http://www.w3.org/ns/shex#> .
+_:c14n18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#ShapeOr> <http://www.w3.org/ns/shex#> .
+_:c14n18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n19 <http://www.w3.org/2002/07/owl#unionOf> _:c14n38 <http://www.w3.org/ns/shex#> .
+_:c14n2 <http://www.w3.org/2002/07/owl#unionOf> _:c14n35 <http://www.w3.org/ns/shex#> .
+_:c14n20 <http://www.w3.org/2002/07/owl#unionOf> _:c14n25 <http://www.w3.org/ns/shex#> .
+_:c14n21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#Stem> <http://www.w3.org/ns/shex#> .
+_:c14n21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n41 <http://www.w3.org/ns/shex#> .
+_:c14n22 <http://www.w3.org/2002/07/owl#unionOf> _:c14n14 <http://www.w3.org/ns/shex#> .
+_:c14n23 <http://www.w3.org/2002/07/owl#unionOf> _:c14n21 <http://www.w3.org/ns/shex#> .
+_:c14n24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#Stem> <http://www.w3.org/ns/shex#> .
+_:c14n24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/ns/shex#> .
+_:c14n25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n26 <http://www.w3.org/ns/shex#> .
+_:c14n26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/ns/shex#> .
+_:c14n26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n27 <http://www.w3.org/ns/shex#> .
+_:c14n27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/ns/shex#> .
+_:c14n27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/ns/shex#> .
+_:c14n28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n29 <http://www.w3.org/ns/shex#> .
+_:c14n29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/ns/shex#> .
+_:c14n29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n30 <http://www.w3.org/ns/shex#> .
+_:c14n3 <http://www.w3.org/2002/07/owl#unionOf> _:c14n11 <http://www.w3.org/ns/shex#> .
+_:c14n30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/ns/shex#> .
+_:c14n30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/ns/shex#> .
+_:c14n31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n12 <http://www.w3.org/ns/shex#> .
+_:c14n32 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/ns/shex#> .
+_:c14n32 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n33 <http://www.w3.org/ns/shex#> .
+_:c14n33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/ns/shex#> .
+_:c14n33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n34 <http://www.w3.org/ns/shex#> .
+_:c14n34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/ns/shex#> .
+_:c14n34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n35 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#EachOf> <http://www.w3.org/ns/shex#> .
+_:c14n35 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n36 <http://www.w3.org/ns/shex#> .
+_:c14n36 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#OneOf> <http://www.w3.org/ns/shex#> .
+_:c14n36 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n37 <http://www.w3.org/ns/shex#> .
+_:c14n37 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/ns/shex#> .
+_:c14n37 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n38 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2000/01/rdf-schema#Resource> <http://www.w3.org/ns/shex#> .
+_:c14n38 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n24 <http://www.w3.org/ns/shex#> .
+_:c14n39 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2000/01/rdf-schema#Resource> <http://www.w3.org/ns/shex#> .
+_:c14n39 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n10 <http://www.w3.org/ns/shex#> .
+_:c14n4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#Wildcard> <http://www.w3.org/ns/shex#> .
+_:c14n4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n40 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/ns/shex#> .
+_:c14n40 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n41 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#StemRange> <http://www.w3.org/ns/shex#> .
+_:c14n41 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n42 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+_:c14n42 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n43 <http://www.w3.org/ns/shex#> .
+_:c14n43 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#decimal> <http://www.w3.org/ns/shex#> .
+_:c14n43 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n44 <http://www.w3.org/ns/shex#> .
+_:c14n44 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#double> <http://www.w3.org/ns/shex#> .
+_:c14n44 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n45 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+_:c14n45 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n46 <http://www.w3.org/ns/shex#> .
+_:c14n46 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#decimal> <http://www.w3.org/ns/shex#> .
+_:c14n46 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n47 <http://www.w3.org/ns/shex#> .
+_:c14n47 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#double> <http://www.w3.org/ns/shex#> .
+_:c14n47 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n48 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+_:c14n48 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n49 <http://www.w3.org/ns/shex#> .
+_:c14n49 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#decimal> <http://www.w3.org/ns/shex#> .
+_:c14n49 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n50 <http://www.w3.org/ns/shex#> .
+_:c14n5 <http://www.w3.org/2002/07/owl#unionOf> _:c14n31 <http://www.w3.org/ns/shex#> .
+_:c14n50 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#double> <http://www.w3.org/ns/shex#> .
+_:c14n50 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n51 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#integer> <http://www.w3.org/ns/shex#> .
+_:c14n51 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n52 <http://www.w3.org/ns/shex#> .
+_:c14n52 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#decimal> <http://www.w3.org/ns/shex#> .
+_:c14n52 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n53 <http://www.w3.org/ns/shex#> .
+_:c14n53 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#double> <http://www.w3.org/ns/shex#> .
+_:c14n53 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n54 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#TripleConstraint> <http://www.w3.org/ns/shex#> .
+_:c14n54 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/shex#> .
+_:c14n6 <http://www.w3.org/2002/07/owl#unionOf> _:c14n51 <http://www.w3.org/ns/shex#> .
+_:c14n7 <http://www.w3.org/2002/07/owl#unionOf> _:c14n28 <http://www.w3.org/ns/shex#> .
+_:c14n8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/shex#Annotation> <http://www.w3.org/ns/shex#> .
+_:c14n8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n54 <http://www.w3.org/ns/shex#> .
+_:c14n9 <http://www.w3.org/2002/07/owl#unionOf> _:c14n8 <http://www.w3.org/ns/shex#> .

--- a/src/prefixes.ts
+++ b/src/prefixes.ts
@@ -54,6 +54,7 @@ const prefixes = {
   sdmx: 'http://purl.org/linked-data/sdmx#',
   sf: 'http://www.opengis.net/ont/sf#',
   sh: 'http://www.w3.org/ns/shacl#',
+  shex: 'http://www.w3.org/ns/shex#',
   sioc: 'http://rdfs.org/sioc/ns#',
   skos: 'http://www.w3.org/2004/02/skos/core#',
   skosxl: 'http://www.w3.org/2008/05/skos-xl#',


### PR DESCRIPTION
Add `shex:`  prefix and vocabulary for Shape Expression Vocabulary (ShEx).

The namespace for ShEx terms is [`http://www.w3.org/ns/shex#`](http://www.w3.org/ns/shex#)  
The suggested prefix for the ShEx namespace is `shex`  

![](https://shex.io/logo/2.1/ShEx-Logo.svg) 

Shape Expression (ShEx) Vocabulary and Term definitions used for describing Shape Expressions in RDF.  Shape Expressions is a structural schema language for RDF graphs. Detailed documentation of ShEx is available at [shex.io](https://shex.io/).