### PR TITLE
Activity Streams were using wrong namespaces

### DIFF
--- a/ontologies/_index.nq
+++ b/ontologies/_index.nq
@@ -7,7 +7,7 @@
 <https://prefix.zazuko.com/as:> <http://purl.org/dc/terms/description> "Extended Activity Streams 2.0 Vocabulary" .
 <https://prefix.zazuko.com/as:> <http://purl.org/dc/terms/title> "Activity Streams 2.0" .
 <https://prefix.zazuko.com/as:> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/rdfa#PrefixMapping> .
-<https://prefix.zazuko.com/as:> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://www.w3.org/ns/activitystreams-owl.ttl> .
+<https://prefix.zazuko.com/as:> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://raw.githubusercontent.com/zazuko/activitystreams/owl-fix/vocabulary/activitystreams2.owl> .
 <https://prefix.zazuko.com/as:> <http://www.w3.org/ns/rdfa#prefix> "as" .
 <https://prefix.zazuko.com/as:> <http://www.w3.org/ns/rdfa#uri> <http://www.w3.org/ns/activitystreams#> .
 <https://prefix.zazuko.com/cc:> <http://dbpedia.org/ontology/filename> "ontologies/cc.nq" .

--- a/ontologies/as.nq
+++ b/ontologies/as.nq
@@ -1,951 +1,939 @@
 <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/ns/activitystreams#> .
+<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/ns/activitystreams#> .
 <http://www.w3.org/2001/XMLSchema#duration> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#> <http://www.w3.org/2000/01/rdf-schema#comment> "Extended Activity Streams 2.0 Vocabulary"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#> <http://www.w3.org/2000/01/rdf-schema#label> "Activity Streams 2.0"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#> <http://www.w3.org/2002/07/owl#imports> <http://www.w3.org/ns/prov#> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor accepts the Object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/2000/01/rdf-schema#label> "Accept"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/2000/01/rdf-schema#comment> "An Object representing some form of Action that has been taken"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/2000/01/rdf-schema#label> "Activity"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Add> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Add> <http://www.w3.org/2000/01/rdf-schema#comment> "To Add an Object or Link to Something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Add> <http://www.w3.org/2000/01/rdf-schema#label> "Add"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Add> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Announce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Announce> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor announces the object to the target"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Announce> <http://www.w3.org/2000/01/rdf-schema#label> "Announce"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Announce> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Application> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Application> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents a software application of any sort"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Application> <http://www.w3.org/2000/01/rdf-schema#label> "Application"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Application> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Arrive> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Arrive> <http://www.w3.org/2000/01/rdf-schema#comment> "To Arrive Somewhere (can be used, for instance, to indicate that a particular entity is currently located somewhere, e.g. a \"check-in\")"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Arrive> <http://www.w3.org/2000/01/rdf-schema#label> "Arrive"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Arrive> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Article> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Article> <http://www.w3.org/2000/01/rdf-schema#comment> "A written work. Typically several paragraphs long. For example, a blog post or a news article."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Article> <http://www.w3.org/2000/01/rdf-schema#label> "Article"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Article> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Audio> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Audio> <http://www.w3.org/2000/01/rdf-schema#comment> "An audio file"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Audio> <http://www.w3.org/2000/01/rdf-schema#label> "Audio"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Audio> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Block> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Block> <http://www.w3.org/2000/01/rdf-schema#label> "Block"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Block> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/2000/01/rdf-schema#comment> "An ordered or unordered collection of Objects or Links"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/2000/01/rdf-schema#label> "Collection"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/2000/01/rdf-schema#comment> "A subset of items from a Collection"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/2000/01/rdf-schema#label> "CollectionPage"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Create> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Create> <http://www.w3.org/2000/01/rdf-schema#comment> "To Create Something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Create> <http://www.w3.org/2000/01/rdf-schema#label> "Create"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Create> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Delete> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Delete> <http://www.w3.org/2000/01/rdf-schema#comment> "To Delete Something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Delete> <http://www.w3.org/2000/01/rdf-schema#label> "Delete"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Delete> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Dislike> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Dislike> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor dislikes the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Dislike> <http://www.w3.org/2000/01/rdf-schema#label> "Dislike"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Dislike> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents a digital document/file of any sort"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/2000/01/rdf-schema#label> "Document"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Event> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Event> <http://www.w3.org/2000/01/rdf-schema#comment> "An Event of any kind"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Event> <http://www.w3.org/2000/01/rdf-schema#label> "Event"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Event> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Flag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Flag> <http://www.w3.org/2000/01/rdf-schema#comment> "To flag something (e.g. flag as inappropriate, flag as spam, etc)"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Flag> <http://www.w3.org/2000/01/rdf-schema#label> "Flag"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Flag> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Follow> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Follow> <http://www.w3.org/2000/01/rdf-schema#comment> "To Express Interest in Something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Follow> <http://www.w3.org/2000/01/rdf-schema#label> "Follow"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Follow> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Group> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Group> <http://www.w3.org/2000/01/rdf-schema#comment> "A Group of any kind."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Group> <http://www.w3.org/2000/01/rdf-schema#label> "Group"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Group> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor is ignoring the Object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/2000/01/rdf-schema#label> "Ignore"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/2000/01/rdf-schema#comment> "An Image file"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/2000/01/rdf-schema#label> "Image"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/2000/01/rdf-schema#comment> "An Activity that has no direct object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/2000/01/rdf-schema#label> "IntransitiveActivity"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/2000/01/rdf-schema#subClassOf> _:c14n46 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Invite> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Invite> <http://www.w3.org/2000/01/rdf-schema#comment> "To invite someone or something to something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Invite> <http://www.w3.org/2000/01/rdf-schema#label> "Invite"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Invite> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Join> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Join> <http://www.w3.org/2000/01/rdf-schema#comment> "To Join Something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Join> <http://www.w3.org/2000/01/rdf-schema#label> "Join"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Join> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Leave> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Leave> <http://www.w3.org/2000/01/rdf-schema#comment> "To Leave Something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Leave> <http://www.w3.org/2000/01/rdf-schema#label> "Leave"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Leave> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Like> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Like> <http://www.w3.org/2000/01/rdf-schema#comment> "To Like Something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Like> <http://www.w3.org/2000/01/rdf-schema#label> "Like"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Like> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents a qualified reference to another resource. Patterned after the RFC5988 Web Linking Model"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/2000/01/rdf-schema#label> "Link"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/2002/07/owl#disjointWith> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Listen> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Listen> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor listened to the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Listen> <http://www.w3.org/2000/01/rdf-schema#label> "Listen"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Listen> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Mention> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Mention> <http://www.w3.org/2000/01/rdf-schema#comment> "A specialized Link that represents an @mention"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Mention> <http://www.w3.org/2000/01/rdf-schema#label> "Mention"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Mention> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Move> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Move> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor is moving the object. The target specifies where the object is moving to. The origin specifies where the object is moving from." <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Move> <http://www.w3.org/2000/01/rdf-schema#label> "Move"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Move> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Note> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Note> <http://www.w3.org/2000/01/rdf-schema#comment> "A Short note, typically less than a single paragraph. A \"tweet\" is an example, or a \"status update\""@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Note> <http://www.w3.org/2000/01/rdf-schema#label> "Note"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Note> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/2000/01/rdf-schema#label> "Object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/2000/01/rdf-schema#comment> "To Offer something to someone or something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/2000/01/rdf-schema#label> "Offer"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/2000/01/rdf-schema#comment> "A variation of Collection in which items are strictly ordered"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/2000/01/rdf-schema#label> "OrderedCollection"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/2000/01/rdf-schema#subClassOf> _:c14n12 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/2000/01/rdf-schema#comment> "An ordered subset of items from an OrderedCollection"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/2000/01/rdf-schema#label> "OrderedCollectionPage"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/2000/01/rdf-schema#comment> "A rdf:List variant for Objects and Links"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/2000/01/rdf-schema#label> "OrderedItems"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/2000/01/rdf-schema#subClassOf> _:c14n47 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Organization> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Organization> <http://www.w3.org/2000/01/rdf-schema#comment> "An Organization"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Organization> <http://www.w3.org/2000/01/rdf-schema#label> "Organization"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Organization> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Page> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Page> <http://www.w3.org/2000/01/rdf-schema#comment> "A Web Page"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Page> <http://www.w3.org/2000/01/rdf-schema#label> "Page"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Page> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Person> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Person> <http://www.w3.org/2000/01/rdf-schema#comment> "A Person"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Person> <http://www.w3.org/2000/01/rdf-schema#label> "Person"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/2000/01/rdf-schema#comment> "A physical or logical location"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/2000/01/rdf-schema#label> "Place"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/2000/01/rdf-schema#comment> "A Profile Document"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/2000/01/rdf-schema#label> "Profile"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/2000/01/rdf-schema#comment> "A question of any sort."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/2000/01/rdf-schema#label> "Question"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Read> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Read> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor read the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Read> <http://www.w3.org/2000/01/rdf-schema#label> "Read"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Read> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor rejects the Object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/2000/01/rdf-schema#label> "Reject"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents a Social Graph relationship between two Individuals (indicated by the 'a' and 'b' properties)"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/2000/01/rdf-schema#label> "Relationship"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Remove> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Remove> <http://www.w3.org/2000/01/rdf-schema#comment> "To Remove Something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Remove> <http://www.w3.org/2000/01/rdf-schema#label> "Remove"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Remove> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Service> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Service> <http://www.w3.org/2000/01/rdf-schema#comment> "A service provided by some entity"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Service> <http://www.w3.org/2000/01/rdf-schema#label> "Service"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Service> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#TentativeAccept> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#TentativeAccept> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor tentatively accepts the Object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#TentativeAccept> <http://www.w3.org/2000/01/rdf-schema#label> "TentativeAccept"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#TentativeAccept> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#TentativeReject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#TentativeReject> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor tentatively rejects the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#TentativeReject> <http://www.w3.org/2000/01/rdf-schema#label> "TentativeReject"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#TentativeReject> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/2000/01/rdf-schema#comment> "A placeholder for a deleted object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/2000/01/rdf-schema#label> "Tombstone"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Travel> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Travel> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor is traveling to the target. The origin specifies where the actor is traveling from." <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Travel> <http://www.w3.org/2000/01/rdf-schema#label> "Travel"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Travel> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Undo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Undo> <http://www.w3.org/2000/01/rdf-schema#comment> "To Undo Something. This would typically be used to indicate that a previous Activity has been undone."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Undo> <http://www.w3.org/2000/01/rdf-schema#label> "Undo"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Undo> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Update> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Update> <http://www.w3.org/2000/01/rdf-schema#comment> "To Update/Modify Something"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Update> <http://www.w3.org/2000/01/rdf-schema#label> "Update"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Update> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Video> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Video> <http://www.w3.org/2000/01/rdf-schema#comment> "A Video document of any kind."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Video> <http://www.w3.org/2000/01/rdf-schema#label> "Video"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#Video> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#View> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#View> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor viewed the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#View> <http://www.w3.org/2000/01/rdf-schema#label> "View"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#View> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the accuracy around the point established by the longitude and latitude"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/2000/01/rdf-schema#label> "accuracy"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n43 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#comment> "Subproperty of as:attributedTo that identifies the primary actor"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#label> "actor"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n28 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/2000/01/rdf-schema#comment> "The altitude of a place"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/2000/01/rdf-schema#label> "altitude"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/2000/01/rdf-schema#comment> "Describes a possible inclusive answer or option for a question."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/2000/01/rdf-schema#label> "oneOf"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n59 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/2000/01/rdf-schema#label> "attachment"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n29 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/2002/07/owl#equivalentProperty> <http://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/2000/01/rdf-schema#label> "attachments"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n53 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/2000/01/rdf-schema#comment> "Identifies an entity to which an object is attributed"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n63 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/2000/01/rdf-schema#label> "attributedTo"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n11 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#audience> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#audience> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#audience> <http://www.w3.org/2000/01/rdf-schema#label> "audience"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#audience> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n35 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#author> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#author> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#comment> "Identifies the author of an object. Deprecated. Use as:attributedTo instead"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#label> "author"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n61 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#bcc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#bcc> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#bcc> <http://www.w3.org/2000/01/rdf-schema#label> "bcc"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#bcc> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n7 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#bto> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#bto> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#bto> <http://www.w3.org/2000/01/rdf-schema#label> "bto"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#bto> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n44 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#cc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#cc> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#cc> <http://www.w3.org/2000/01/rdf-schema#label> "cc"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#cc> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n64 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#content> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#content> <http://www.w3.org/2000/01/rdf-schema#comment> "The content of the object."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#content> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#content> <http://www.w3.org/2000/01/rdf-schema#label> "content"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#content> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n72 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#context> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#context> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the context within which an object exists or an activity was performed"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#context> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#context> <http://www.w3.org/2000/01/rdf-schema#label> "context"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#context> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n14 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#current> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#current> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#current> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#current> <http://www.w3.org/2000/01/rdf-schema#label> "current"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#current> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n19 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the date and time the object was deleted"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/2000/01/rdf-schema#label> "deleted"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/2000/01/rdf-schema#comment> "On a Profile object, describes the object described by the profile"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/2000/01/rdf-schema#label> "describes"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#label> "downstreamDuplicates"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/2000/01/rdf-schema#comment> "The duration of the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/2000/01/rdf-schema#label> "duration"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#duration> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/2000/01/rdf-schema#comment> "The ending time of the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/2000/01/rdf-schema#label> "endTime"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#first> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#first> <http://www.w3.org/2000/01/rdf-schema#label> "first"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#first> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n26 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/2000/01/rdf-schema#comment> "On a Tombstone object, describes the former type of the deleted object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/2000/01/rdf-schema#label> "formerType"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#generator> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#generator> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#generator> <http://www.w3.org/2000/01/rdf-schema#label> "generator"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#generator> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n77 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#height> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#height> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#height> <http://www.w3.org/2000/01/rdf-schema#comment> "The display height expressed as device independent pixels"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#height> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#height> <http://www.w3.org/2000/01/rdf-schema#label> "height"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#height> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#href> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#href> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#href> <http://www.w3.org/2000/01/rdf-schema#comment> "The target URI of the Link"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#href> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#href> <http://www.w3.org/2000/01/rdf-schema#label> "href"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#href> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/2000/01/rdf-schema#comment> "A hint about the language of the referenced resource"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/2000/01/rdf-schema#label> "hreflang"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#language> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#icon> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#icon> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#icon> <http://www.w3.org/2000/01/rdf-schema#label> "icon"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#icon> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n73 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#id> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#id> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#id> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#id> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n32 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#id> <http://www.w3.org/2000/01/rdf-schema#label> "id"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#id> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#image> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#image> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#image> <http://www.w3.org/2000/01/rdf-schema#label> "image"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#image> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n49 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#inReplyTo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#inReplyTo> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#inReplyTo> <http://www.w3.org/2000/01/rdf-schema#label> "inReplyTo"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#inReplyTo> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n65 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/2000/01/rdf-schema#comment> "Indentifies an object used (or to be used) to complete an activity"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/2000/01/rdf-schema#label> "instrument"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n31 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#items> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#items> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#items> <http://www.w3.org/2000/01/rdf-schema#label> "items"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#items> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n4 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#last> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#last> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#last> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#last> <http://www.w3.org/2000/01/rdf-schema#label> "last"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#last> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n58 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/2000/01/rdf-schema#comment> "The latitude"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/2000/01/rdf-schema#label> "latitude"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#location> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#location> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#location> <http://www.w3.org/2000/01/rdf-schema#label> "location"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#location> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n5 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/2000/01/rdf-schema#comment> "The longitude"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/2000/01/rdf-schema#label> "longitude"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/2000/01/rdf-schema#comment> "The MIME Media Type"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n22 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/2000/01/rdf-schema#label> "mediaType"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#name> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n21 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#name> <http://www.w3.org/2000/01/rdf-schema#label> "name"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#name> <http://www.w3.org/2000/01/rdf-schema#name> "The default, plain-text display name of the object or link."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#name> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n16 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#next> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#next> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#next> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#next> <http://www.w3.org/2000/01/rdf-schema#label> "next"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#next> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n36 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#object> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#object> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n70 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#object> <http://www.w3.org/2000/01/rdf-schema#label> "object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#object> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n27 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/2000/01/rdf-schema#label> "objectType"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/2000/01/rdf-schema#comment> "Describes a possible exclusive answer or option for a question."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/2000/01/rdf-schema#label> "oneOf"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n68 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/2000/01/rdf-schema#comment> "For certain activities, specifies the entity from which the action is directed."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/2000/01/rdf-schema#label> "origin"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n67 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/2000/01/rdf-schema#label> "partOf"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n9 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/2000/01/rdf-schema#label> "prev"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n10 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#preview> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#preview> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n1 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#preview> <http://www.w3.org/2000/01/rdf-schema#label> "preview"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#preview> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n60 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/2000/01/rdf-schema#label> "provider"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n50 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#published> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#published> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#published> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the date and time the object was published"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#published> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#published> <http://www.w3.org/2000/01/rdf-schema#label> "published"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#published> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies a radius around the point established by the longitude and latitude"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/2000/01/rdf-schema#label> "radius"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n51 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/2000/01/rdf-schema#comment> "A numeric rating (>= 0.0, <= 5.0) for the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/2000/01/rdf-schema#label> "rating"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n6 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/2000/01/rdf-schema#comment> "The RFC 5988 or HTML5 Link Relation associated with the Link"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/2000/01/rdf-schema#label> "rel"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#comment> "On a Relationship object, describes the type of relationship"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#label> "relationship"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#replies> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#replies> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#replies> <http://www.w3.org/2000/01/rdf-schema#label> "replies"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#replies> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#result> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#result> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#result> <http://www.w3.org/2000/01/rdf-schema#label> "result"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#result> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n76 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/2000/01/rdf-schema#comment> "In a strictly ordered logical collection, specifies the index position of the first item in the items list"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/2000/01/rdf-schema#label> "startIndex"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/2000/01/rdf-schema#comment> "The starting time of the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/2000/01/rdf-schema#label> "startTime"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#comment> "On a Relationship object, identifies the subject. e.g. when saying \"John is connected to Sally\", 'subject' refers to 'John'"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#label> "a"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n75 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/2000/01/rdf-schema#comment> "A short summary of the object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/2000/01/rdf-schema#label> "summary"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n40 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/2000/01/rdf-schema#label> "tag"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n52 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/2000/01/rdf-schema#label> "tags"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n69 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/2002/07/owl#equivalentProperty> <http://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#target> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#target> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#target> <http://www.w3.org/2000/01/rdf-schema#label> "target"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#target> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n62 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#to> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#to> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#to> <http://www.w3.org/2000/01/rdf-schema#label> "to"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#to> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n0 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/2000/01/rdf-schema#comment> "The total number of items in a logical collection"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/2000/01/rdf-schema#label> "totalItems"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#units> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#units> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#units> <http://www.w3.org/2000/01/rdf-schema#comment> "Identifies the unit of measurement used by the radius, altitude and accuracy properties. The value can be expressed either as one of a set of predefined units or as a well-known common URI that identifies units."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#units> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#units> <http://www.w3.org/2000/01/rdf-schema#label> "units"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#units> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n20 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies when the object was last updated"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/2000/01/rdf-schema#label> "updated"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#label> "upstreamDuplicates"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#url> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#url> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies a link to a specific representation of the Object"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#url> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#url> <http://www.w3.org/2000/01/rdf-schema#label> "url"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#url> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n15 <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/2000/01/rdf-schema#label> "verb"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#width> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#width> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#width> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the preferred display width of the content, expressed in terms of device independent pixels."@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#width> <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#width> <http://www.w3.org/2000/01/rdf-schema#label> "width"@en <http://www.w3.org/ns/activitystreams#> .
-<http://www.w3.org/ns/activitystreams#width> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#> <http://www.w3.org/2000/01/rdf-schema#comment> "Extended Activity Streams 2.0 Vocabulary"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#> <http://www.w3.org/2000/01/rdf-schema#label> "Activity Streams 2.0"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#> <http://www.w3.org/2002/07/owl#imports> <http://www.w3.org/ns/prov#> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor accepts the Object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/2000/01/rdf-schema#label> "Accept"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/2000/01/rdf-schema#comment> "An Object representing some form of Action that has been taken"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/2000/01/rdf-schema#label> "Activity"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Add> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Add> <http://www.w3.org/2000/01/rdf-schema#comment> "To Add an Object or Link to Something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Add> <http://www.w3.org/2000/01/rdf-schema#label> "Add"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Add> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Announce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Announce> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor announces the object to the target"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Announce> <http://www.w3.org/2000/01/rdf-schema#label> "Announce"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Announce> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Application> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Application> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents a software application of any sort"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Application> <http://www.w3.org/2000/01/rdf-schema#label> "Application"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Application> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Arrive> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Arrive> <http://www.w3.org/2000/01/rdf-schema#comment> "To Arrive Somewhere (can be used, for instance, to indicate that a particular entity is currently located somewhere, e.g. a \"check-in\")"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Arrive> <http://www.w3.org/2000/01/rdf-schema#label> "Arrive"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Arrive> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Article> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Article> <http://www.w3.org/2000/01/rdf-schema#comment> "A written work. Typically several paragraphs long. For example, a blog post or a news article."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Article> <http://www.w3.org/2000/01/rdf-schema#label> "Article"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Article> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Audio> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Audio> <http://www.w3.org/2000/01/rdf-schema#comment> "An audio file"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Audio> <http://www.w3.org/2000/01/rdf-schema#label> "Audio"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Audio> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Block> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Block> <http://www.w3.org/2000/01/rdf-schema#label> "Block"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Block> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/2000/01/rdf-schema#comment> "An ordered or unordered collection of Objects or Links"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/2000/01/rdf-schema#label> "Collection"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/2000/01/rdf-schema#comment> "A subset of items from a Collection"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/2000/01/rdf-schema#label> "CollectionPage"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Create> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Create> <http://www.w3.org/2000/01/rdf-schema#comment> "To Create Something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Create> <http://www.w3.org/2000/01/rdf-schema#label> "Create"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Create> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Delete> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Delete> <http://www.w3.org/2000/01/rdf-schema#comment> "To Delete Something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Delete> <http://www.w3.org/2000/01/rdf-schema#label> "Delete"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Delete> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Dislike> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Dislike> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor dislikes the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Dislike> <http://www.w3.org/2000/01/rdf-schema#label> "Dislike"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Dislike> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents a digital document/file of any sort"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/2000/01/rdf-schema#label> "Document"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Event> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Event> <http://www.w3.org/2000/01/rdf-schema#comment> "An Event of any kind"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Event> <http://www.w3.org/2000/01/rdf-schema#label> "Event"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Event> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Flag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Flag> <http://www.w3.org/2000/01/rdf-schema#comment> "To flag something (e.g. flag as inappropriate, flag as spam, etc)"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Flag> <http://www.w3.org/2000/01/rdf-schema#label> "Flag"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Flag> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Follow> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Follow> <http://www.w3.org/2000/01/rdf-schema#comment> "To Express Interest in Something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Follow> <http://www.w3.org/2000/01/rdf-schema#label> "Follow"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Follow> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Group> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Group> <http://www.w3.org/2000/01/rdf-schema#comment> "A Group of any kind."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Group> <http://www.w3.org/2000/01/rdf-schema#label> "Group"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Group> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor is ignoring the Object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/2000/01/rdf-schema#label> "Ignore"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Ignore> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/2000/01/rdf-schema#comment> "An Image file"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/2000/01/rdf-schema#label> "Image"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/2000/01/rdf-schema#comment> "An Activity that has no direct object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/2000/01/rdf-schema#label> "IntransitiveActivity"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/2000/01/rdf-schema#subClassOf> _:c14n41 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Invite> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Invite> <http://www.w3.org/2000/01/rdf-schema#comment> "To invite someone or something to something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Invite> <http://www.w3.org/2000/01/rdf-schema#label> "Invite"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Invite> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Join> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Join> <http://www.w3.org/2000/01/rdf-schema#comment> "To Join Something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Join> <http://www.w3.org/2000/01/rdf-schema#label> "Join"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Join> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Leave> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Leave> <http://www.w3.org/2000/01/rdf-schema#comment> "To Leave Something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Leave> <http://www.w3.org/2000/01/rdf-schema#label> "Leave"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Leave> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Like> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Like> <http://www.w3.org/2000/01/rdf-schema#comment> "To Like Something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Like> <http://www.w3.org/2000/01/rdf-schema#label> "Like"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Like> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents a qualified reference to another resource. Patterned after the RFC5988 Web Linking Model"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/2000/01/rdf-schema#label> "Link"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/2002/07/owl#disjointWith> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Listen> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Listen> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor listened to the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Listen> <http://www.w3.org/2000/01/rdf-schema#label> "Listen"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Listen> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Mention> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Mention> <http://www.w3.org/2000/01/rdf-schema#comment> "A specialized Link that represents an @mention"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Mention> <http://www.w3.org/2000/01/rdf-schema#label> "Mention"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Mention> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Move> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Move> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor is moving the object. The target specifies where the object is moving to. The origin specifies where the object is moving from." <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Move> <http://www.w3.org/2000/01/rdf-schema#label> "Move"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Move> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Note> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Note> <http://www.w3.org/2000/01/rdf-schema#comment> "A Short note, typically less than a single paragraph. A \"tweet\" is an example, or a \"status update\""@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Note> <http://www.w3.org/2000/01/rdf-schema#label> "Note"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Note> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/2000/01/rdf-schema#label> "Object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/2000/01/rdf-schema#comment> "To Offer something to someone or something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/2000/01/rdf-schema#label> "Offer"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Offer> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/2000/01/rdf-schema#comment> "A variation of Collection in which items are strictly ordered"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/2000/01/rdf-schema#label> "OrderedCollection"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/2000/01/rdf-schema#subClassOf> _:c14n66 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/2000/01/rdf-schema#comment> "An ordered subset of items from an OrderedCollection"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/2000/01/rdf-schema#label> "OrderedCollectionPage"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#OrderedCollection> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/2000/01/rdf-schema#comment> "A rdf:List variant for Objects and Links"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/2000/01/rdf-schema#label> "OrderedItems"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/2000/01/rdf-schema#subClassOf> _:c14n0 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Organization> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Organization> <http://www.w3.org/2000/01/rdf-schema#comment> "An Organization"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Organization> <http://www.w3.org/2000/01/rdf-schema#label> "Organization"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Organization> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Page> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Page> <http://www.w3.org/2000/01/rdf-schema#comment> "A Web Page"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Page> <http://www.w3.org/2000/01/rdf-schema#label> "Page"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Page> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Person> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Person> <http://www.w3.org/2000/01/rdf-schema#comment> "A Person"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Person> <http://www.w3.org/2000/01/rdf-schema#label> "Person"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/2000/01/rdf-schema#comment> "A physical or logical location"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/2000/01/rdf-schema#label> "Place"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/2000/01/rdf-schema#comment> "A Profile Document"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/2000/01/rdf-schema#label> "Profile"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/2000/01/rdf-schema#comment> "A question of any sort."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/2000/01/rdf-schema#label> "Question"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Read> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Read> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor read the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Read> <http://www.w3.org/2000/01/rdf-schema#label> "Read"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Read> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor rejects the Object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/2000/01/rdf-schema#label> "Reject"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents a Social Graph relationship between two Individuals (indicated by the 'a' and 'b' properties)"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/2000/01/rdf-schema#label> "Relationship"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Remove> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Remove> <http://www.w3.org/2000/01/rdf-schema#comment> "To Remove Something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Remove> <http://www.w3.org/2000/01/rdf-schema#label> "Remove"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Remove> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Service> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Service> <http://www.w3.org/2000/01/rdf-schema#comment> "A service provided by some entity"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Service> <http://www.w3.org/2000/01/rdf-schema#label> "Service"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Service> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#TentativeAccept> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#TentativeAccept> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor tentatively accepts the Object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#TentativeAccept> <http://www.w3.org/2000/01/rdf-schema#label> "TentativeAccept"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#TentativeAccept> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Accept> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#TentativeReject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#TentativeReject> <http://www.w3.org/2000/01/rdf-schema#comment> "Actor tentatively rejects the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#TentativeReject> <http://www.w3.org/2000/01/rdf-schema#label> "TentativeReject"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#TentativeReject> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Reject> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/2000/01/rdf-schema#comment> "A placeholder for a deleted object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/2000/01/rdf-schema#label> "Tombstone"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Travel> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Travel> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor is traveling to the target. The origin specifies where the actor is traveling from." <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Travel> <http://www.w3.org/2000/01/rdf-schema#label> "Travel"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Travel> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#IntransitiveActivity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Undo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Undo> <http://www.w3.org/2000/01/rdf-schema#comment> "To Undo Something. This would typically be used to indicate that a previous Activity has been undone."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Undo> <http://www.w3.org/2000/01/rdf-schema#label> "Undo"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Undo> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Update> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Update> <http://www.w3.org/2000/01/rdf-schema#comment> "To Update/Modify Something"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Update> <http://www.w3.org/2000/01/rdf-schema#label> "Update"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Update> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Video> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Video> <http://www.w3.org/2000/01/rdf-schema#comment> "A Video document of any kind."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Video> <http://www.w3.org/2000/01/rdf-schema#label> "Video"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#Video> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Document> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#View> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#View> <http://www.w3.org/2000/01/rdf-schema#comment> "The actor viewed the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#View> <http://www.w3.org/2000/01/rdf-schema#label> "View"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#View> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the accuracy around the point established by the longitude and latitude"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/2000/01/rdf-schema#label> "accuracy"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#accuracy> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n46 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#comment> "Subproperty of as:attributedTo that identifies the primary actor"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#label> "actor"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n18 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#actor> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/2000/01/rdf-schema#comment> "The altitude of a place"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/2000/01/rdf-schema#label> "altitude"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#altitude> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/2000/01/rdf-schema#comment> "Describes a possible inclusive answer or option for a question."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/2000/01/rdf-schema#label> "oneOf"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#anyOf> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n3 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/2000/01/rdf-schema#label> "attachment"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n9 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachment> <http://www.w3.org/2002/07/owl#equivalentProperty> <https://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/2000/01/rdf-schema#label> "attachments"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attachments> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n36 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/2000/01/rdf-schema#comment> "Identifies an entity to which an object is attributed"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n7 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/2000/01/rdf-schema#label> "attributedTo"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n59 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#audience> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#audience> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#audience> <http://www.w3.org/2000/01/rdf-schema#label> "audience"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#audience> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n68 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#author> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#author> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#comment> "Identifies the author of an object. Deprecated. Use as:attributedTo instead"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#label> "author"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n56 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#author> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://www.w3.org/ns/activitystreams#attributedTo> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#bcc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#bcc> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#bcc> <http://www.w3.org/2000/01/rdf-schema#label> "bcc"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#bcc> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n10 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#bto> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#bto> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#bto> <http://www.w3.org/2000/01/rdf-schema#label> "bto"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#bto> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n74 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#cc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#cc> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#cc> <http://www.w3.org/2000/01/rdf-schema#label> "cc"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#cc> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n62 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#content> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#content> <http://www.w3.org/2000/01/rdf-schema#comment> "The content of the object."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#content> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#content> <http://www.w3.org/2000/01/rdf-schema#label> "content"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#content> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n67 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#context> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#context> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the context within which an object exists or an activity was performed"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#context> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#context> <http://www.w3.org/2000/01/rdf-schema#label> "context"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#context> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n53 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#current> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#current> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#current> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#current> <http://www.w3.org/2000/01/rdf-schema#label> "current"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#current> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n8 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the date and time the object was deleted"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/2000/01/rdf-schema#label> "deleted"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#deleted> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/2000/01/rdf-schema#comment> "On a Profile object, describes the object described by the profile"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Profile> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/2000/01/rdf-schema#label> "describes"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#describes> <http://www.w3.org/2000/01/rdf-schema#range> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#label> "downstreamDuplicates"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#downstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/2000/01/rdf-schema#comment> "The duration of the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/2000/01/rdf-schema#label> "duration"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#duration> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#duration> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/2000/01/rdf-schema#comment> "The ending time of the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/2000/01/rdf-schema#label> "endTime"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#endTime> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#first> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#first> <http://www.w3.org/2000/01/rdf-schema#label> "first"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#first> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n24 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/2000/01/rdf-schema#comment> "On a Tombstone object, describes the former type of the deleted object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Tombstone> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/2000/01/rdf-schema#label> "formerType"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#formerType> <http://www.w3.org/2000/01/rdf-schema#range> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#generator> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#generator> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#generator> <http://www.w3.org/2000/01/rdf-schema#label> "generator"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#generator> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n61 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#height> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#height> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#height> <http://www.w3.org/2000/01/rdf-schema#comment> "The display height expressed as device independent pixels"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#height> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#height> <http://www.w3.org/2000/01/rdf-schema#label> "height"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#height> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#href> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#href> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#href> <http://www.w3.org/2000/01/rdf-schema#comment> "The target URI of the Link"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#href> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#href> <http://www.w3.org/2000/01/rdf-schema#label> "href"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#href> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/2000/01/rdf-schema#comment> "A hint about the language of the referenced resource"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/2000/01/rdf-schema#label> "hreflang"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#hreflang> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#language> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#icon> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#icon> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#icon> <http://www.w3.org/2000/01/rdf-schema#label> "icon"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#icon> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n70 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#image> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#image> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#image> <http://www.w3.org/2000/01/rdf-schema#label> "image"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#image> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n43 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#inReplyTo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#inReplyTo> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#inReplyTo> <http://www.w3.org/2000/01/rdf-schema#label> "inReplyTo"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#inReplyTo> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n57 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/2000/01/rdf-schema#comment> "Indentifies an object used (or to be used) to complete an activity"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/2000/01/rdf-schema#label> "instrument"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#instrument> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n63 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#items> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#items> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#items> <http://www.w3.org/2000/01/rdf-schema#label> "items"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#items> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n17 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#last> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#last> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#last> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#last> <http://www.w3.org/2000/01/rdf-schema#label> "last"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#last> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n47 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/2000/01/rdf-schema#comment> "The latitude"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/2000/01/rdf-schema#label> "latitude"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#latitude> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#location> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#location> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#location> <http://www.w3.org/2000/01/rdf-schema#label> "location"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#location> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n31 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/2000/01/rdf-schema#comment> "The longitude"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/2000/01/rdf-schema#label> "longitude"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#longitude> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/2000/01/rdf-schema#comment> "The MIME Media Type"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n50 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/2000/01/rdf-schema#label> "mediaType"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#mediaType> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#name> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n16 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#name> <http://www.w3.org/2000/01/rdf-schema#label> "name"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#name> <http://www.w3.org/2000/01/rdf-schema#name> "The default, plain-text display name of the object or link."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#name> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n6 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#next> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#next> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#next> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#next> <http://www.w3.org/2000/01/rdf-schema#label> "next"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#next> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n42 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#object> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#object> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n60 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#object> <http://www.w3.org/2000/01/rdf-schema#label> "object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#object> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n77 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/2000/01/rdf-schema#label> "objectType"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#objectType> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/2000/01/rdf-schema#comment> "Describes a possible exclusive answer or option for a question."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Question> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/2000/01/rdf-schema#label> "oneOf"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#oneOf> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n55 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/2000/01/rdf-schema#comment> "For certain activities, specifies the entity from which the action is directed."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/2000/01/rdf-schema#label> "origin"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#origin> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n37 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/2000/01/rdf-schema#label> "partOf"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#partOf> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n29 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/2000/01/rdf-schema#label> "prev"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#prev> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n35 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#preview> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#preview> <http://www.w3.org/2000/01/rdf-schema#domain> _:c14n65 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#preview> <http://www.w3.org/2000/01/rdf-schema#label> "preview"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#preview> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n13 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/2000/01/rdf-schema#label> "provider"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#provider> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n27 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#published> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#published> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#published> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the date and time the object was published"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#published> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#published> <http://www.w3.org/2000/01/rdf-schema#label> "published"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#published> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies a radius around the point established by the longitude and latitude"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/2000/01/rdf-schema#label> "radius"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#radius> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n33 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/2000/01/rdf-schema#comment> "A numeric rating (>= 0.0, <= 5.0) for the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/2000/01/rdf-schema#label> "rating"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rating> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n48 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/2000/01/rdf-schema#comment> "The RFC 5988 or HTML5 Link Relation associated with the Link"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/2000/01/rdf-schema#label> "rel"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#rel> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#comment> "On a Relationship object, describes the type of relationship"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#label> "relationship"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#relationship> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#replies> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#replies> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#replies> <http://www.w3.org/2000/01/rdf-schema#label> "replies"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#replies> <http://www.w3.org/2000/01/rdf-schema#range> <https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#result> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#result> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#result> <http://www.w3.org/2000/01/rdf-schema#label> "result"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#result> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n39 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/2000/01/rdf-schema#comment> "In a strictly ordered logical collection, specifies the index position of the first item in the items list"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#OrderedCollectionPage> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/2000/01/rdf-schema#label> "startIndex"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startIndex> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/2000/01/rdf-schema#comment> "The starting time of the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/2000/01/rdf-schema#label> "startTime"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#startTime> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#comment> "On a Relationship object, identifies the subject. e.g. when saying \"John is connected to Sally\", 'subject' refers to 'John'"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#label> "a"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n71 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#subject> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/2000/01/rdf-schema#comment> "A short summary of the object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/2000/01/rdf-schema#label> "summary"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#summary> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n54 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/2000/01/rdf-schema#label> "tag"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n12 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/2000/01/rdf-schema#label> "tags"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n30 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#tags> <http://www.w3.org/2002/07/owl#equivalentProperty> <https://www.w3.org/ns/activitystreams#tag> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#target> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#target> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#target> <http://www.w3.org/2000/01/rdf-schema#label> "target"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#target> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n4 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#to> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#to> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#to> <http://www.w3.org/2000/01/rdf-schema#label> "to"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#to> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n32 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/2000/01/rdf-schema#comment> "The total number of items in a logical collection"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/2000/01/rdf-schema#label> "totalItems"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#totalItems> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#units> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#units> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#units> <http://www.w3.org/2000/01/rdf-schema#comment> "Identifies the unit of measurement used by the radius, altitude and accuracy properties. The value can be expressed either as one of a set of predefined units or as a well-known common URI that identifies units."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#units> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Place> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#units> <http://www.w3.org/2000/01/rdf-schema#label> "units"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#units> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n44 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies when the object was last updated"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/2000/01/rdf-schema#label> "updated"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#updated> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#dateTime> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#label> "upstreamDuplicates"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#upstreamDuplicates> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#url> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#url> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies a link to a specific representation of the Object"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#url> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#url> <http://www.w3.org/2000/01/rdf-schema#label> "url"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#url> <http://www.w3.org/2000/01/rdf-schema#range> _:c14n11 <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DeprecatedProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/2000/01/rdf-schema#label> "verb"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#verb> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#width> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#width> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#width> <http://www.w3.org/2000/01/rdf-schema#comment> "Specifies the preferred display width of the content, expressed in terms of device independent pixels."@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#width> <http://www.w3.org/2000/01/rdf-schema#domain> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#width> <http://www.w3.org/2000/01/rdf-schema#label> "width"@en <http://www.w3.org/ns/activitystreams#> .
+<https://www.w3.org/ns/activitystreams#width> <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
 _:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n0 <http://www.w3.org/2002/07/owl#unionOf> _:c14n131 <http://www.w3.org/ns/activitystreams#> .
-_:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n1 <http://www.w3.org/2002/07/owl#unionOf> _:c14n163 <http://www.w3.org/ns/activitystreams#> .
+_:c14n0 <http://www.w3.org/2002/07/owl#intersectionOf> _:c14n14 <http://www.w3.org/ns/activitystreams#> .
+_:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "inches" <http://www.w3.org/ns/activitystreams#> .
+_:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n21 <http://www.w3.org/ns/activitystreams#> .
 _:c14n10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n10 <http://www.w3.org/2002/07/owl#unionOf> _:c14n90 <http://www.w3.org/ns/activitystreams#> .
-_:c14n100 <http://www.w3.org/2001/XMLSchema#minInclusive> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-_:c14n101 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n100 <http://www.w3.org/ns/activitystreams#> .
+_:c14n10 <http://www.w3.org/2002/07/owl#unionOf> _:c14n134 <http://www.w3.org/ns/activitystreams#> .
+_:c14n100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n101 <http://www.w3.org/ns/activitystreams#> .
+_:c14n101 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n101 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n102 <http://www.w3.org/2001/XMLSchema#minInclusive> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-_:c14n103 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n102 <http://www.w3.org/ns/activitystreams#> .
+_:c14n102 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n102 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n103 <http://www.w3.org/ns/activitystreams#> .
+_:c14n103 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n103 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n104 <http://www.w3.org/2001/XMLSchema#minInclusive> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-_:c14n105 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/ns/activitystreams#> .
-_:c14n105 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n106 <http://www.w3.org/ns/activitystreams#> .
-_:c14n106 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n106 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n107 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/ns/activitystreams#> .
-_:c14n107 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n108 <http://www.w3.org/ns/activitystreams#> .
-_:c14n108 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n108 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n109 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
+_:c14n104 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n104 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n105 <http://www.w3.org/ns/activitystreams#> .
+_:c14n105 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n105 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n106 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n106 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n107 <http://www.w3.org/ns/activitystreams#> .
+_:c14n107 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n107 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n108 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n108 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n109 <http://www.w3.org/ns/activitystreams#> .
+_:c14n109 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n109 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
 _:c14n11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n11 <http://www.w3.org/2002/07/owl#unionOf> _:c14n161 <http://www.w3.org/ns/activitystreams#> .
-_:c14n110 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> <http://www.w3.org/ns/activitystreams#> .
-_:c14n110 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n109 <http://www.w3.org/ns/activitystreams#> .
-_:c14n111 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
+_:c14n11 <http://www.w3.org/2002/07/owl#unionOf> _:c14n80 <http://www.w3.org/ns/activitystreams#> .
+_:c14n110 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n110 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n111 <http://www.w3.org/ns/activitystreams#> .
+_:c14n111 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n111 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n112 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> <http://www.w3.org/ns/activitystreams#> .
-_:c14n112 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n111 <http://www.w3.org/ns/activitystreams#> .
-_:c14n113 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
+_:c14n112 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n112 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n113 <http://www.w3.org/ns/activitystreams#> .
+_:c14n113 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n113 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n114 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> <http://www.w3.org/ns/activitystreams#> .
-_:c14n114 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n113 <http://www.w3.org/ns/activitystreams#> .
-_:c14n115 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n55 <http://www.w3.org/ns/activitystreams#> .
+_:c14n114 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n114 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n115 <http://www.w3.org/ns/activitystreams#> .
+_:c14n115 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n115 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n116 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n57 <http://www.w3.org/ns/activitystreams#> .
-_:c14n116 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n117 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n24 <http://www.w3.org/ns/activitystreams#> .
+_:c14n116 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n116 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n117 <http://www.w3.org/ns/activitystreams#> .
+_:c14n117 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n117 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n118 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n78 <http://www.w3.org/ns/activitystreams#> .
-_:c14n118 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n119 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n119 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n120 <http://www.w3.org/ns/activitystreams#> .
+_:c14n118 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n118 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n119 <http://www.w3.org/ns/activitystreams#> .
+_:c14n119 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n119 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
 _:c14n12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n12 <http://www.w3.org/2002/07/owl#intersectionOf> _:c14n41 <http://www.w3.org/ns/activitystreams#> .
-_:c14n120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n121 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n121 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n122 <http://www.w3.org/ns/activitystreams#> .
-_:c14n122 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n122 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n124 <http://www.w3.org/ns/activitystreams#> .
-_:c14n124 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n124 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n125 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n125 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n126 <http://www.w3.org/ns/activitystreams#> .
-_:c14n126 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n126 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n127 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n127 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n128 <http://www.w3.org/ns/activitystreams#> .
-_:c14n128 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n128 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n129 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n129 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n130 <http://www.w3.org/ns/activitystreams#> .
-_:c14n13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
-_:c14n13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n179 <http://www.w3.org/ns/activitystreams#> .
-_:c14n130 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n130 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n131 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n131 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n132 <http://www.w3.org/ns/activitystreams#> .
-_:c14n132 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n132 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n133 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n133 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n134 <http://www.w3.org/ns/activitystreams#> .
-_:c14n134 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n134 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n135 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n135 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n136 <http://www.w3.org/ns/activitystreams#> .
-_:c14n136 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n136 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n137 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n137 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n138 <http://www.w3.org/ns/activitystreams#> .
-_:c14n138 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n138 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n139 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n139 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n140 <http://www.w3.org/ns/activitystreams#> .
-_:c14n14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n14 <http://www.w3.org/2002/07/owl#unionOf> _:c14n151 <http://www.w3.org/ns/activitystreams#> .
-_:c14n140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n141 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n141 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n142 <http://www.w3.org/ns/activitystreams#> .
-_:c14n142 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n142 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n143 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n143 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n144 <http://www.w3.org/ns/activitystreams#> .
-_:c14n144 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n144 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n145 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n145 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n146 <http://www.w3.org/ns/activitystreams#> .
-_:c14n146 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n146 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n147 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n147 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n148 <http://www.w3.org/ns/activitystreams#> .
-_:c14n148 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n148 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n149 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n149 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n150 <http://www.w3.org/ns/activitystreams#> .
-_:c14n15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n15 <http://www.w3.org/2002/07/owl#unionOf> _:c14n85 <http://www.w3.org/ns/activitystreams#> .
-_:c14n150 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n150 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n151 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n151 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n152 <http://www.w3.org/ns/activitystreams#> .
-_:c14n152 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n152 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n153 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n153 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n154 <http://www.w3.org/ns/activitystreams#> .
-_:c14n154 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n154 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n155 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n155 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n156 <http://www.w3.org/ns/activitystreams#> .
-_:c14n156 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n156 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n157 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n157 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n158 <http://www.w3.org/ns/activitystreams#> .
-_:c14n158 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n12 <http://www.w3.org/2002/07/owl#unionOf> _:c14n116 <http://www.w3.org/ns/activitystreams#> .
+_:c14n120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n121 <http://www.w3.org/ns/activitystreams#> .
+_:c14n121 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n121 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n122 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n122 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n123 <http://www.w3.org/ns/activitystreams#> .
+_:c14n123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n123 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n124 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n124 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n125 <http://www.w3.org/ns/activitystreams#> .
+_:c14n125 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n125 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n126 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n126 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n127 <http://www.w3.org/ns/activitystreams#> .
+_:c14n127 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n127 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n128 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n128 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n129 <http://www.w3.org/ns/activitystreams#> .
+_:c14n129 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n129 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n13 <http://www.w3.org/2002/07/owl#unionOf> _:c14n98 <http://www.w3.org/ns/activitystreams#> .
+_:c14n130 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n130 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n131 <http://www.w3.org/ns/activitystreams#> .
+_:c14n131 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n131 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n132 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n132 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n133 <http://www.w3.org/ns/activitystreams#> .
+_:c14n133 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n133 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n134 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n134 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n135 <http://www.w3.org/ns/activitystreams#> .
+_:c14n135 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n135 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n136 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n136 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n137 <http://www.w3.org/ns/activitystreams#> .
+_:c14n137 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n137 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n138 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n138 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n139 <http://www.w3.org/ns/activitystreams#> .
+_:c14n139 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n139 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#List> <http://www.w3.org/ns/activitystreams#> .
+_:c14n14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n20 <http://www.w3.org/ns/activitystreams#> .
+_:c14n140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n141 <http://www.w3.org/ns/activitystreams#> .
+_:c14n141 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n141 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n142 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n142 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n143 <http://www.w3.org/ns/activitystreams#> .
+_:c14n143 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n143 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n144 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n144 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n145 <http://www.w3.org/ns/activitystreams#> .
+_:c14n145 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n145 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n146 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n146 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n147 <http://www.w3.org/ns/activitystreams#> .
+_:c14n147 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n147 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n148 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n148 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n149 <http://www.w3.org/ns/activitystreams#> .
+_:c14n149 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n149 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "m" <http://www.w3.org/ns/activitystreams#> .
+_:c14n15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n75 <http://www.w3.org/ns/activitystreams#> .
+_:c14n150 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n150 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n151 <http://www.w3.org/ns/activitystreams#> .
+_:c14n151 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n151 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n152 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n152 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n153 <http://www.w3.org/ns/activitystreams#> .
+_:c14n153 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n153 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n154 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n154 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n155 <http://www.w3.org/ns/activitystreams#> .
+_:c14n155 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n155 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n156 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n156 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n157 <http://www.w3.org/ns/activitystreams#> .
+_:c14n157 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n157 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n158 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n52 <http://www.w3.org/ns/activitystreams#> .
 _:c14n158 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n159 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n159 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n160 <http://www.w3.org/ns/activitystreams#> .
+_:c14n159 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n25 <http://www.w3.org/ns/activitystreams#> .
+_:c14n159 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
 _:c14n16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n16 <http://www.w3.org/2002/07/owl#unionOf> _:c14n110 <http://www.w3.org/ns/activitystreams#> .
-_:c14n160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n16 <http://www.w3.org/2002/07/owl#unionOf> _:c14n128 <http://www.w3.org/ns/activitystreams#> .
+_:c14n160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n76 <http://www.w3.org/ns/activitystreams#> .
 _:c14n160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n161 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n161 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n162 <http://www.w3.org/ns/activitystreams#> .
-_:c14n162 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n162 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n163 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n163 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n164 <http://www.w3.org/ns/activitystreams#> .
-_:c14n164 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n164 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n165 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n165 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n166 <http://www.w3.org/ns/activitystreams#> .
-_:c14n166 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n161 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n72 <http://www.w3.org/ns/activitystreams#> .
+_:c14n161 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n162 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/ns/activitystreams#> .
+_:c14n162 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n163 <http://www.w3.org/ns/activitystreams#> .
+_:c14n163 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n163 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n164 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Image> <http://www.w3.org/ns/activitystreams#> .
+_:c14n164 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n165 <http://www.w3.org/ns/activitystreams#> .
+_:c14n165 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n165 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n166 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n166 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n167 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n167 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n168 <http://www.w3.org/ns/activitystreams#> .
-_:c14n168 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n168 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n169 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n169 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n170 <http://www.w3.org/ns/activitystreams#> .
-_:c14n17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#List> <http://www.w3.org/ns/activitystreams#> .
-_:c14n17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n25 <http://www.w3.org/ns/activitystreams#> .
-_:c14n170 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n170 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n171 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n171 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n172 <http://www.w3.org/ns/activitystreams#> .
-_:c14n172 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n172 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n173 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n173 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n174 <http://www.w3.org/ns/activitystreams#> .
-_:c14n174 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n174 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n175 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n175 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n176 <http://www.w3.org/ns/activitystreams#> .
-_:c14n176 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n176 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n177 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n177 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n178 <http://www.w3.org/ns/activitystreams#> .
-_:c14n178 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n178 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n179 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n179 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "m" <http://www.w3.org/ns/activitystreams#> .
-_:c14n18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n74 <http://www.w3.org/ns/activitystreams#> .
+_:c14n167 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n167 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n168 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+_:c14n168 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n167 <http://www.w3.org/ns/activitystreams#> .
+_:c14n169 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n169 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n17 <http://www.w3.org/2002/07/owl#unionOf> _:c14n79 <http://www.w3.org/ns/activitystreams#> .
+_:c14n170 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+_:c14n170 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n169 <http://www.w3.org/ns/activitystreams#> .
+_:c14n171 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n171 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n172 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+_:c14n172 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n171 <http://www.w3.org/ns/activitystreams#> .
+_:c14n173 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n173 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n174 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+_:c14n174 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n173 <http://www.w3.org/ns/activitystreams#> .
+_:c14n175 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n175 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n176 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+_:c14n176 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n175 <http://www.w3.org/ns/activitystreams#> .
+_:c14n18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n18 <http://www.w3.org/2002/07/owl#unionOf> _:c14n110 <http://www.w3.org/ns/activitystreams#> .
 _:c14n19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n19 <http://www.w3.org/2002/07/owl#unionOf> _:c14n98 <http://www.w3.org/ns/activitystreams#> .
-_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "inches" <http://www.w3.org/ns/activitystreams#> .
-_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n30 <http://www.w3.org/ns/activitystreams#> .
-_:c14n20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
-_:c14n20 <http://www.w3.org/2002/07/owl#unionOf> _:c14n80 <http://www.w3.org/ns/activitystreams#> .
-_:c14n21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n21 <http://www.w3.org/2002/07/owl#unionOf> _:c14n141 <http://www.w3.org/ns/activitystreams#> .
-_:c14n22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n22 <http://www.w3.org/2002/07/owl#unionOf> _:c14n86 <http://www.w3.org/ns/activitystreams#> .
-_:c14n23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n23 <http://www.w3.org/2002/07/owl#unionOf> _:c14n121 <http://www.w3.org/ns/activitystreams#> .
-_:c14n24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> <http://www.w3.org/ns/activitystreams#> .
-_:c14n24 <http://www.w3.org/2002/07/owl#allValuesFrom> <http://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/ns/activitystreams#> .
-_:c14n24 <http://www.w3.org/2002/07/owl#onProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/ns/activitystreams#> .
-_:c14n25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n8 <http://www.w3.org/ns/activitystreams#> .
-_:c14n25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n117 <http://www.w3.org/ns/activitystreams#> .
+_:c14n19 <http://www.w3.org/2002/07/owl#unionOf> _:c14n148 <http://www.w3.org/ns/activitystreams#> .
+_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
+_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n5 <http://www.w3.org/ns/activitystreams#> .
+_:c14n20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n159 <http://www.w3.org/ns/activitystreams#> .
+_:c14n21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "feet" <http://www.w3.org/ns/activitystreams#> .
+_:c14n21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n34 <http://www.w3.org/ns/activitystreams#> .
+_:c14n22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "cm" <http://www.w3.org/ns/activitystreams#> .
+_:c14n22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n15 <http://www.w3.org/ns/activitystreams#> .
+_:c14n23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2002/07/owl#Thing> <http://www.w3.org/ns/activitystreams#> .
+_:c14n23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n24 <http://www.w3.org/2002/07/owl#unionOf> _:c14n174 <http://www.w3.org/ns/activitystreams#> .
+_:c14n25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> <http://www.w3.org/ns/activitystreams#> .
+_:c14n25 <http://www.w3.org/2002/07/owl#allValuesFrom> <https://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/ns/activitystreams#> .
+_:c14n25 <http://www.w3.org/2002/07/owl#onProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/ns/activitystreams#> .
 _:c14n26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n26 <http://www.w3.org/2002/07/owl#unionOf> _:c14n94 <http://www.w3.org/ns/activitystreams#> .
+_:c14n26 <http://www.w3.org/2002/07/owl#unionOf> _:c14n136 <http://www.w3.org/ns/activitystreams#> .
 _:c14n27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n27 <http://www.w3.org/2002/07/owl#unionOf> _:c14n153 <http://www.w3.org/ns/activitystreams#> .
-_:c14n28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n28 <http://www.w3.org/2002/07/owl#unionOf> _:c14n177 <http://www.w3.org/ns/activitystreams#> .
+_:c14n27 <http://www.w3.org/2002/07/owl#unionOf> _:c14n152 <http://www.w3.org/ns/activitystreams#> .
+_:c14n28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/ns/activitystreams#> .
+_:c14n28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
 _:c14n29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n29 <http://www.w3.org/2002/07/owl#unionOf> _:c14n83 <http://www.w3.org/ns/activitystreams#> .
-_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#anyURI> <http://www.w3.org/ns/activitystreams#> .
-_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "feet" <http://www.w3.org/ns/activitystreams#> .
-_:c14n30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n48 <http://www.w3.org/ns/activitystreams#> .
+_:c14n29 <http://www.w3.org/2002/07/owl#unionOf> _:c14n38 <http://www.w3.org/ns/activitystreams#> .
+_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n3 <http://www.w3.org/2002/07/owl#unionOf> _:c14n130 <http://www.w3.org/ns/activitystreams#> .
+_:c14n30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n30 <http://www.w3.org/2002/07/owl#unionOf> _:c14n146 <http://www.w3.org/ns/activitystreams#> .
 _:c14n31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n31 <http://www.w3.org/2002/07/owl#unionOf> _:c14n135 <http://www.w3.org/ns/activitystreams#> .
+_:c14n31 <http://www.w3.org/2002/07/owl#unionOf> _:c14n138 <http://www.w3.org/ns/activitystreams#> .
 _:c14n32 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n32 <http://www.w3.org/2002/07/owl#unionOf> _:c14n81 <http://www.w3.org/ns/activitystreams#> .
-_:c14n33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
-_:c14n33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n38 <http://www.w3.org/ns/activitystreams#> .
-_:c14n34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "cm" <http://www.w3.org/ns/activitystreams#> .
-_:c14n34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n18 <http://www.w3.org/ns/activitystreams#> .
+_:c14n32 <http://www.w3.org/2002/07/owl#unionOf> _:c14n122 <http://www.w3.org/ns/activitystreams#> .
+_:c14n33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
+_:c14n33 <http://www.w3.org/2002/07/owl#onDatatype> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
+_:c14n33 <http://www.w3.org/2002/07/owl#withRestrictions> _:c14n88 <http://www.w3.org/ns/activitystreams#> .
+_:c14n34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "miles" <http://www.w3.org/ns/activitystreams#> .
+_:c14n34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n22 <http://www.w3.org/ns/activitystreams#> .
 _:c14n35 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n35 <http://www.w3.org/2002/07/owl#unionOf> _:c14n143 <http://www.w3.org/ns/activitystreams#> .
+_:c14n35 <http://www.w3.org/2002/07/owl#unionOf> _:c14n170 <http://www.w3.org/ns/activitystreams#> .
 _:c14n36 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n36 <http://www.w3.org/2002/07/owl#unionOf> _:c14n92 <http://www.w3.org/ns/activitystreams#> .
-_:c14n37 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2002/07/owl#Thing> <http://www.w3.org/ns/activitystreams#> .
-_:c14n37 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n38 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Relationship> <http://www.w3.org/ns/activitystreams#> .
-_:c14n38 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n36 <http://www.w3.org/2002/07/owl#unionOf> _:c14n108 <http://www.w3.org/ns/activitystreams#> .
+_:c14n37 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n37 <http://www.w3.org/2002/07/owl#unionOf> _:c14n104 <http://www.w3.org/ns/activitystreams#> .
+_:c14n38 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
+_:c14n38 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n166 <http://www.w3.org/ns/activitystreams#> .
 _:c14n39 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n39 <http://www.w3.org/2002/07/owl#unionOf> _:c14n125 <http://www.w3.org/ns/activitystreams#> .
+_:c14n39 <http://www.w3.org/2002/07/owl#unionOf> _:c14n144 <http://www.w3.org/ns/activitystreams#> .
 _:c14n4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n4 <http://www.w3.org/2002/07/owl#unionOf> _:c14n79 <http://www.w3.org/ns/activitystreams#> .
-_:c14n40 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n40 <http://www.w3.org/2002/07/owl#unionOf> _:c14n112 <http://www.w3.org/ns/activitystreams#> .
-_:c14n41 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
-_:c14n41 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n115 <http://www.w3.org/ns/activitystreams#> .
-_:c14n42 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/ns/activitystreams#> .
-_:c14n42 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n116 <http://www.w3.org/ns/activitystreams#> .
-_:c14n43 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
-_:c14n43 <http://www.w3.org/2002/07/owl#onDatatype> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-_:c14n43 <http://www.w3.org/2002/07/owl#withRestrictions> _:c14n101 <http://www.w3.org/ns/activitystreams#> .
-_:c14n44 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n44 <http://www.w3.org/2002/07/owl#unionOf> _:c14n175 <http://www.w3.org/ns/activitystreams#> .
-_:c14n45 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/ns/activitystreams#> .
-_:c14n45 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n46 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> <http://www.w3.org/ns/activitystreams#> .
-_:c14n46 <http://www.w3.org/2002/07/owl#maxCardinality> "0"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
-_:c14n46 <http://www.w3.org/2002/07/owl#onProperty> <http://www.w3.org/ns/activitystreams#object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n4 <http://www.w3.org/2002/07/owl#unionOf> _:c14n112 <http://www.w3.org/ns/activitystreams#> .
+_:c14n40 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Activity> <http://www.w3.org/ns/activitystreams#> .
+_:c14n40 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n28 <http://www.w3.org/ns/activitystreams#> .
+_:c14n41 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> <http://www.w3.org/ns/activitystreams#> .
+_:c14n41 <http://www.w3.org/2002/07/owl#maxCardinality> "0"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> <http://www.w3.org/ns/activitystreams#> .
+_:c14n41 <http://www.w3.org/2002/07/owl#onProperty> <https://www.w3.org/ns/activitystreams#object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n42 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n42 <http://www.w3.org/2002/07/owl#unionOf> _:c14n168 <http://www.w3.org/ns/activitystreams#> .
+_:c14n43 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n43 <http://www.w3.org/2002/07/owl#unionOf> _:c14n162 <http://www.w3.org/ns/activitystreams#> .
+_:c14n44 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
+_:c14n44 <http://www.w3.org/2002/07/owl#unionOf> _:c14n78 <http://www.w3.org/ns/activitystreams#> .
+_:c14n45 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/ns/activitystreams#> .
+_:c14n45 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n158 <http://www.w3.org/ns/activitystreams#> .
+_:c14n46 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
+_:c14n46 <http://www.w3.org/2002/07/owl#onDatatype> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
+_:c14n46 <http://www.w3.org/2002/07/owl#withRestrictions> _:c14n90 <http://www.w3.org/ns/activitystreams#> .
 _:c14n47 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n47 <http://www.w3.org/2002/07/owl#intersectionOf> _:c14n17 <http://www.w3.org/ns/activitystreams#> .
-_:c14n48 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "miles" <http://www.w3.org/ns/activitystreams#> .
-_:c14n48 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n34 <http://www.w3.org/ns/activitystreams#> .
+_:c14n47 <http://www.w3.org/2002/07/owl#unionOf> _:c14n176 <http://www.w3.org/ns/activitystreams#> .
+_:c14n48 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
+_:c14n48 <http://www.w3.org/2002/07/owl#onDatatype> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
+_:c14n48 <http://www.w3.org/2002/07/owl#withRestrictions> _:c14n64 <http://www.w3.org/ns/activitystreams#> .
 _:c14n49 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n49 <http://www.w3.org/2002/07/owl#unionOf> _:c14n105 <http://www.w3.org/ns/activitystreams#> .
-_:c14n5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n5 <http://www.w3.org/2002/07/owl#unionOf> _:c14n165 <http://www.w3.org/ns/activitystreams#> .
+_:c14n49 <http://www.w3.org/2002/07/owl#unionOf> _:c14n150 <http://www.w3.org/ns/activitystreams#> .
+_:c14n5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> <http://www.w3.org/ns/activitystreams#> .
+_:c14n5 <http://www.w3.org/2002/07/owl#allValuesFrom> _:c14n19 <http://www.w3.org/ns/activitystreams#> .
+_:c14n5 <http://www.w3.org/2002/07/owl#onProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#> .
 _:c14n50 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n50 <http://www.w3.org/2002/07/owl#unionOf> _:c14n169 <http://www.w3.org/ns/activitystreams#> .
+_:c14n50 <http://www.w3.org/2002/07/owl#unionOf> _:c14n85 <http://www.w3.org/ns/activitystreams#> .
 _:c14n51 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
-_:c14n51 <http://www.w3.org/2002/07/owl#onDatatype> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-_:c14n51 <http://www.w3.org/2002/07/owl#withRestrictions> _:c14n103 <http://www.w3.org/ns/activitystreams#> .
+_:c14n51 <http://www.w3.org/2002/07/owl#oneOf> _:c14n1 <http://www.w3.org/ns/activitystreams#> .
 _:c14n52 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n52 <http://www.w3.org/2002/07/owl#unionOf> _:c14n159 <http://www.w3.org/ns/activitystreams#> .
+_:c14n52 <http://www.w3.org/2002/07/owl#complementOf> _:c14n49 <http://www.w3.org/ns/activitystreams#> .
 _:c14n53 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n53 <http://www.w3.org/2002/07/owl#unionOf> _:c14n147 <http://www.w3.org/ns/activitystreams#> .
+_:c14n53 <http://www.w3.org/2002/07/owl#unionOf> _:c14n100 <http://www.w3.org/ns/activitystreams#> .
 _:c14n54 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n54 <http://www.w3.org/2002/07/owl#unionOf> _:c14n167 <http://www.w3.org/ns/activitystreams#> .
-_:c14n55 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> <http://www.w3.org/ns/activitystreams#> .
-_:c14n55 <http://www.w3.org/2002/07/owl#allValuesFrom> _:c14n71 <http://www.w3.org/ns/activitystreams#> .
-_:c14n55 <http://www.w3.org/2002/07/owl#onProperty> <http://www.w3.org/ns/activitystreams#items> <http://www.w3.org/ns/activitystreams#> .
-_:c14n56 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
-_:c14n56 <http://www.w3.org/2002/07/owl#oneOf> _:c14n2 <http://www.w3.org/ns/activitystreams#> .
+_:c14n54 <http://www.w3.org/2002/07/owl#unionOf> _:c14n97 <http://www.w3.org/ns/activitystreams#> .
+_:c14n55 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n55 <http://www.w3.org/2002/07/owl#unionOf> _:c14n120 <http://www.w3.org/ns/activitystreams#> .
+_:c14n56 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n56 <http://www.w3.org/2002/07/owl#unionOf> _:c14n142 <http://www.w3.org/ns/activitystreams#> .
 _:c14n57 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n57 <http://www.w3.org/2002/07/owl#complementOf> _:c14n54 <http://www.w3.org/ns/activitystreams#> .
-_:c14n58 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n58 <http://www.w3.org/2002/07/owl#unionOf> _:c14n96 <http://www.w3.org/ns/activitystreams#> .
+_:c14n57 <http://www.w3.org/2002/07/owl#unionOf> _:c14n132 <http://www.w3.org/ns/activitystreams#> .
+_:c14n58 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#OrderedItems> <http://www.w3.org/ns/activitystreams#> .
+_:c14n58 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
 _:c14n59 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n59 <http://www.w3.org/2002/07/owl#unionOf> _:c14n119 <http://www.w3.org/ns/activitystreams#> .
-_:c14n6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Datatype> <http://www.w3.org/ns/activitystreams#> .
-_:c14n6 <http://www.w3.org/2002/07/owl#onDatatype> <http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-_:c14n6 <http://www.w3.org/2002/07/owl#withRestrictions> _:c14n66 <http://www.w3.org/ns/activitystreams#> .
+_:c14n59 <http://www.w3.org/2002/07/owl#unionOf> _:c14n156 <http://www.w3.org/ns/activitystreams#> .
+_:c14n6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n6 <http://www.w3.org/2002/07/owl#unionOf> _:c14n95 <http://www.w3.org/ns/activitystreams#> .
 _:c14n60 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n60 <http://www.w3.org/2002/07/owl#unionOf> _:c14n127 <http://www.w3.org/ns/activitystreams#> .
+_:c14n60 <http://www.w3.org/2002/07/owl#unionOf> _:c14n40 <http://www.w3.org/ns/activitystreams#> .
 _:c14n61 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n61 <http://www.w3.org/2002/07/owl#unionOf> _:c14n133 <http://www.w3.org/ns/activitystreams#> .
+_:c14n61 <http://www.w3.org/2002/07/owl#unionOf> _:c14n106 <http://www.w3.org/ns/activitystreams#> .
 _:c14n62 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n62 <http://www.w3.org/2002/07/owl#unionOf> _:c14n139 <http://www.w3.org/ns/activitystreams#> .
+_:c14n62 <http://www.w3.org/2002/07/owl#unionOf> _:c14n118 <http://www.w3.org/ns/activitystreams#> .
 _:c14n63 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n63 <http://www.w3.org/2002/07/owl#unionOf> _:c14n171 <http://www.w3.org/ns/activitystreams#> .
-_:c14n64 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n64 <http://www.w3.org/2002/07/owl#unionOf> _:c14n155 <http://www.w3.org/ns/activitystreams#> .
+_:c14n63 <http://www.w3.org/2002/07/owl#unionOf> _:c14n124 <http://www.w3.org/ns/activitystreams#> .
+_:c14n64 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n91 <http://www.w3.org/ns/activitystreams#> .
+_:c14n64 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n160 <http://www.w3.org/ns/activitystreams#> .
 _:c14n65 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n65 <http://www.w3.org/2002/07/owl#unionOf> _:c14n123 <http://www.w3.org/ns/activitystreams#> .
-_:c14n66 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n104 <http://www.w3.org/ns/activitystreams#> .
-_:c14n66 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n118 <http://www.w3.org/ns/activitystreams#> .
+_:c14n65 <http://www.w3.org/2002/07/owl#unionOf> _:c14n140 <http://www.w3.org/ns/activitystreams#> .
+_:c14n66 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n66 <http://www.w3.org/2002/07/owl#intersectionOf> _:c14n73 <http://www.w3.org/ns/activitystreams#> .
 _:c14n67 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n67 <http://www.w3.org/2002/07/owl#unionOf> _:c14n173 <http://www.w3.org/ns/activitystreams#> .
+_:c14n67 <http://www.w3.org/2002/07/owl#unionOf> _:c14n93 <http://www.w3.org/ns/activitystreams#> .
 _:c14n68 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n68 <http://www.w3.org/2002/07/owl#unionOf> _:c14n157 <http://www.w3.org/ns/activitystreams#> .
+_:c14n68 <http://www.w3.org/2002/07/owl#unionOf> _:c14n102 <http://www.w3.org/ns/activitystreams#> .
 _:c14n69 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n69 <http://www.w3.org/2002/07/owl#unionOf> _:c14n145 <http://www.w3.org/ns/activitystreams#> .
+_:c14n69 <http://www.w3.org/2002/07/owl#intersectionOf> _:c14n45 <http://www.w3.org/ns/activitystreams#> .
 _:c14n7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n7 <http://www.w3.org/2002/07/owl#unionOf> _:c14n149 <http://www.w3.org/ns/activitystreams#> .
+_:c14n7 <http://www.w3.org/2002/07/owl#unionOf> _:c14n114 <http://www.w3.org/ns/activitystreams#> .
 _:c14n70 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n70 <http://www.w3.org/2002/07/owl#unionOf> _:c14n33 <http://www.w3.org/ns/activitystreams#> .
+_:c14n70 <http://www.w3.org/2002/07/owl#unionOf> _:c14n164 <http://www.w3.org/ns/activitystreams#> .
 _:c14n71 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n71 <http://www.w3.org/2002/07/owl#intersectionOf> _:c14n42 <http://www.w3.org/ns/activitystreams#> .
-_:c14n72 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n72 <http://www.w3.org/2002/07/owl#unionOf> _:c14n114 <http://www.w3.org/ns/activitystreams#> .
-_:c14n73 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n73 <http://www.w3.org/2002/07/owl#unionOf> _:c14n107 <http://www.w3.org/ns/activitystreams#> .
-_:c14n74 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "km" <http://www.w3.org/ns/activitystreams#> .
-_:c14n74 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n75 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n75 <http://www.w3.org/2002/07/owl#unionOf> _:c14n88 <http://www.w3.org/ns/activitystreams#> .
-_:c14n76 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n76 <http://www.w3.org/2002/07/owl#unionOf> _:c14n129 <http://www.w3.org/ns/activitystreams#> .
+_:c14n71 <http://www.w3.org/2002/07/owl#unionOf> _:c14n83 <http://www.w3.org/ns/activitystreams#> .
+_:c14n72 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> <http://www.w3.org/ns/activitystreams#> .
+_:c14n72 <http://www.w3.org/2002/07/owl#allValuesFrom> _:c14n69 <http://www.w3.org/ns/activitystreams#> .
+_:c14n72 <http://www.w3.org/2002/07/owl#onProperty> <https://www.w3.org/ns/activitystreams#items> <http://www.w3.org/ns/activitystreams#> .
+_:c14n73 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Collection> <http://www.w3.org/ns/activitystreams#> .
+_:c14n73 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n161 <http://www.w3.org/ns/activitystreams#> .
+_:c14n74 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n74 <http://www.w3.org/2002/07/owl#unionOf> _:c14n126 <http://www.w3.org/ns/activitystreams#> .
+_:c14n75 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "km" <http://www.w3.org/ns/activitystreams#> .
+_:c14n75 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n76 <http://www.w3.org/2001/XMLSchema#maxInclusive> "5.0"^^<http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
 _:c14n77 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n77 <http://www.w3.org/2002/07/owl#unionOf> _:c14n137 <http://www.w3.org/ns/activitystreams#> .
-_:c14n78 <http://www.w3.org/2001/XMLSchema#maxInclusive> "5.0"^^<http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
-_:c14n79 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n39 <http://www.w3.org/ns/activitystreams#> .
-_:c14n79 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n45 <http://www.w3.org/ns/activitystreams#> .
-_:c14n8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> <http://www.w3.org/ns/activitystreams#> .
-_:c14n8 <http://www.w3.org/2002/07/owl#allValuesFrom> _:c14n23 <http://www.w3.org/ns/activitystreams#> .
-_:c14n8 <http://www.w3.org/2002/07/owl#onProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#> .
-_:c14n80 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n56 <http://www.w3.org/ns/activitystreams#> .
-_:c14n80 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n3 <http://www.w3.org/ns/activitystreams#> .
-_:c14n81 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n77 <http://www.w3.org/2002/07/owl#unionOf> _:c14n154 <http://www.w3.org/ns/activitystreams#> .
+_:c14n78 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n51 <http://www.w3.org/ns/activitystreams#> .
+_:c14n78 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n2 <http://www.w3.org/ns/activitystreams#> .
+_:c14n79 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n26 <http://www.w3.org/ns/activitystreams#> .
+_:c14n79 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n58 <http://www.w3.org/ns/activitystreams#> .
+_:c14n8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
+_:c14n8 <http://www.w3.org/2002/07/owl#unionOf> _:c14n172 <http://www.w3.org/ns/activitystreams#> .
+_:c14n80 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n80 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n23 <http://www.w3.org/ns/activitystreams#> .
+_:c14n81 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n81 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n82 <http://www.w3.org/ns/activitystreams#> .
-_:c14n82 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n82 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
 _:c14n82 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n83 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n83 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n83 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n84 <http://www.w3.org/ns/activitystreams#> .
-_:c14n84 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n84 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
 _:c14n84 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n85 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n85 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n37 <http://www.w3.org/ns/activitystreams#> .
-_:c14n86 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n86 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n87 <http://www.w3.org/ns/activitystreams#> .
-_:c14n87 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n87 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n88 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n88 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n89 <http://www.w3.org/ns/activitystreams#> .
-_:c14n89 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
-_:c14n89 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n85 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n85 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n86 <http://www.w3.org/ns/activitystreams#> .
+_:c14n86 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
+_:c14n86 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n87 <http://www.w3.org/2001/XMLSchema#minInclusive> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
+_:c14n88 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n87 <http://www.w3.org/ns/activitystreams#> .
+_:c14n88 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n89 <http://www.w3.org/2001/XMLSchema#minInclusive> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
 _:c14n9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> <http://www.w3.org/ns/activitystreams#> .
-_:c14n9 <http://www.w3.org/2002/07/owl#unionOf> _:c14n13 <http://www.w3.org/ns/activitystreams#> .
-_:c14n90 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
-_:c14n90 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n91 <http://www.w3.org/ns/activitystreams#> .
-_:c14n91 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n91 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n92 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
-_:c14n92 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n93 <http://www.w3.org/ns/activitystreams#> .
-_:c14n93 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n93 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n94 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
-_:c14n94 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n95 <http://www.w3.org/ns/activitystreams#> .
-_:c14n95 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n95 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n96 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
-_:c14n96 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n97 <http://www.w3.org/ns/activitystreams#> .
-_:c14n97 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
-_:c14n97 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
-_:c14n98 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#CollectionPage> <http://www.w3.org/ns/activitystreams#> .
+_:c14n9 <http://www.w3.org/2002/07/owl#unionOf> _:c14n81 <http://www.w3.org/ns/activitystreams#> .
+_:c14n90 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n89 <http://www.w3.org/ns/activitystreams#> .
+_:c14n90 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n91 <http://www.w3.org/2001/XMLSchema#minInclusive> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> <http://www.w3.org/ns/activitystreams#> .
+_:c14n92 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
+_:c14n92 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n93 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> <http://www.w3.org/ns/activitystreams#> .
+_:c14n93 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n92 <http://www.w3.org/ns/activitystreams#> .
+_:c14n94 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
+_:c14n94 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n95 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> <http://www.w3.org/ns/activitystreams#> .
+_:c14n95 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n94 <http://www.w3.org/ns/activitystreams#> .
+_:c14n96 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2001/XMLSchema#string> <http://www.w3.org/ns/activitystreams#> .
+_:c14n96 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .
+_:c14n97 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> <http://www.w3.org/ns/activitystreams#> .
+_:c14n97 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n96 <http://www.w3.org/ns/activitystreams#> .
+_:c14n98 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Object> <http://www.w3.org/ns/activitystreams#> .
 _:c14n98 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n99 <http://www.w3.org/ns/activitystreams#> .
-_:c14n99 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
+_:c14n99 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://www.w3.org/ns/activitystreams#Link> <http://www.w3.org/ns/activitystreams#> .
 _:c14n99 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> <http://www.w3.org/ns/activitystreams#> .

--- a/overrides.ts
+++ b/overrides.ts
@@ -12,7 +12,7 @@ export interface Override extends FileSpec {
 }
 
 export const overrides: Record<string, Override> = {
-  as: { file: 'https://www.w3.org/ns/activitystreams-owl.ttl', mediaType: 'text/turtle' },
+  as: { file: 'https://raw.githubusercontent.com/zazuko/activitystreams/owl-fix/vocabulary/activitystreams2.owl', mediaType: 'text/turtle' },
   dbo: {
     files: [{
       mediaType: 'text/n3',


### PR DESCRIPTION
I also removed `as:id` which should not exist as property

Hard to tell when the fixes will be merged in the w3c repo so run-in off a Zazuko fork for the time being